### PR TITLE
 Hybrid pipe docs update (value‑first vs function‑first)

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,8 +120,8 @@ There's no framework and no heavy abstractions—just well-chosen helpers that m
   // [4, 8, 12, 16, 20]
   ```
 
-- **Data-first with `from`**
-  Use `from` to inject constant values in pipelines and enable data-first patterns. Particularly useful with `ifElse` and `cond` for constant branches.
+- **Hybrid data-first / data-last**
+  `pipe`/`pipeAsync` accept either functions-first (returns a reusable function) or value-first (executes immediately). Value-first improves inference because the first value anchors generics. If the first argument is a function, it is treated as composition; wrap function values with `from` when you need to pass them as data. Use `from` to inject constants (e.g., in `ifElse`/`cond`) or to start a pipeline without input.
 
   ```typescript
   import { pipe, ifElse, from, filter, map } from 'fp-pack';
@@ -135,7 +135,7 @@ There's no framework and no heavy abstractions—just well-chosen helpers that m
 
   const result = getStatusLabel(75); // 'pass'
 
-  // Data-first pattern: inject data into pipeline
+  // Start a pipeline without input
   const processWithData = pipe(
     from([1, 2, 3, 4, 5]),
     filter((n: number) => n % 2 === 0),
@@ -213,7 +213,7 @@ The add-on is located at `node_modules/fp-pack/dist/ai-addons/fp-pack-agent-addo
 
 ### Basic Pipe Composition
 
-`pipe` is a pure function composition tool - it takes functions and returns a new function that applies data to those composed functions.
+`pipe` composes functions left-to-right. Use functions-first to create a reusable pipeline, or value-first to execute immediately (value-first often improves type inference because the input anchors generics).
 
 ```typescript
 import { pipe, map, filter, take } from 'fp-pack';
@@ -228,12 +228,23 @@ const processUsers = pipe(
 const result = processUsers(users);
 ```
 
-**Data-first with `from` (optional)**: While `pipe` is designed for composing functions, you can optionally use `from` to inject data directly into pipelines for convenience:
+**Data-first invocation (recommended for inference)**: Pass the input as the first argument to execute immediately.
+
+```typescript
+import { pipe, filter, map } from 'fp-pack';
+
+const result = pipe(
+  [1, 2, 3, 4, 5],
+  filter((n: number) => n % 2 === 0),
+  map(n => n * 2)
+); // [4, 8]
+```
+
+**Constant values with `from` (optional)**: Use `from` to inject constants into pipelines or to start a pipeline with no input.
 
 ```typescript
 import { pipe, from, filter, map } from 'fp-pack';
 
-// Optional: data-first pattern with from
 const processData = pipe(
   from([1, 2, 3, 4, 5]),
   filter((n: number) => n % 2 === 0),

--- a/docs/src/pages/AIAgentSkills.tsx
+++ b/docs/src/pages/AIAgentSkills.tsx
@@ -34,6 +34,7 @@ export const AIAgentSkills = () => (
     </p>
 
     <ul class="list-disc list-inside space-y-2 text-sm md:text-base text-gray-700 dark:text-gray-300 mb-6">
+      <li>Prefer value-first <code class="text-sm">pipe(data, ...)</code>/<code class="text-sm">pipeAsync(data, ...)</code> for inference</li>
       <li>Default to using <code class="text-sm">pipe</code>/<code class="text-sm">pipeAsync</code> for pure transformations</li>
       <li>Use <code class="text-sm">pipeSideEffect</code>/<code class="text-sm">pipeAsyncSideEffect</code> when SideEffect is involved</li>
       <li>Use strict variants (<code class="text-sm">pipeSideEffectStrict</code>/<code class="text-sm">pipeAsyncSideEffectStrict</code>) when you need strict effect unions</li>
@@ -109,7 +110,7 @@ Copy-Item node_modules/fp-pack/dist/skills/fp-pack/SKILL.md $HOME/.codex/skills/
 3. Use the patterns shown in real-world examples
 
 **Non-negotiable rules:**
-- Use \`from()\` for constants, NOT \`() => value\`
+- Prefer \`pipe(data, ...)\` for inference; use \`from(value)\` for zero-arg pipelines (avoid \`() => value\`)
 - Use \`pipeSideEffect\` for SideEffect handling, NOT \`pipe\`
 - Call \`runPipeResult\` OUTSIDE pipelines, NEVER inside
 - Use immutable operations, NO mutations

--- a/docs/src/pages/AIAgentSkills_ko.tsx
+++ b/docs/src/pages/AIAgentSkills_ko.tsx
@@ -34,6 +34,7 @@ export const AIAgentSkills_ko = () => (
     </p>
 
     <ul class="list-disc list-inside space-y-2 text-sm md:text-base text-gray-700 dark:text-gray-300 mb-6">
+      <li>타입 추론을 위해 <code class="text-sm">pipe(data, ...)</code>/<code class="text-sm">pipeAsync(data, ...)</code> 형태를 우선 사용</li>
       <li>순수 변환에는 기본적으로 <code class="text-sm">pipe</code>/<code class="text-sm">pipeAsync</code> 사용</li>
       <li>SideEffect가 필요할 때 <code class="text-sm">pipeSideEffect</code>/<code class="text-sm">pipeAsyncSideEffect</code> 사용</li>
       <li>엄격한 effect 유니온이 필요할 때 strict 변형(<code class="text-sm">pipeSideEffectStrict</code>/<code class="text-sm">pipeAsyncSideEffectStrict</code>) 사용</li>
@@ -109,7 +110,7 @@ Copy-Item node_modules/fp-pack/dist/skills/fp-pack/SKILL.md $HOME/.codex/skills/
 3. 실전 예제에 나온 패턴을 사용해야 합니다
 
 **위반 불가 규칙:**
-- 상수에는 \`from()\` 사용, \`() => value\` 사용 금지
+- 타입 추론을 위해 \`pipe(data, ...)\` 우선 사용; 인자 없는 파이프는 \`from(value)\` 사용 (\`() => value\` 금지)
 - SideEffect 처리에는 \`pipeSideEffect\` 사용, \`pipe\` 사용 금지
 - \`runPipeResult\`는 파이프라인 밖에서만 호출, 안에서 호출 금지
 - 불변 연산 사용, 변경(mutation) 금지

--- a/docs/src/pages/PipeAsync.tsx
+++ b/docs/src/pages/PipeAsync.tsx
@@ -8,7 +8,7 @@ export const PipeAsync = () => (
     </h1>
 
     <p class="text-lg text-gray-600 dark:text-gray-400 mb-8">
-      Compose async (or mixed) functions left-to-right, returning a function
+      Compose async (or mixed) functions left-to-right with value-first or functions-first calls
     </p>
 
     <hr class="border-t border-gray-200 dark:border-gray-700 my-10" />
@@ -21,20 +21,20 @@ export const PipeAsync = () => (
       <strong class="font-semibold text-blue-700 dark:text-blue-300 bg-blue-100 dark:bg-blue-900/20 px-2 py-1 rounded">
         pipeAsync
       </strong>{' '}
-      takes async/sync functions and returns a new function. Calling it runs each step in order, awaiting promises as
-      needed. Signature: <code>pipeAsync(fn1, fn2, ...)(value)</code>.
+      takes async/sync functions and runs each step in order, awaiting promises as needed. Prefer value-first for
+      immediate execution and stronger inference: <code>pipeAsync(value, fn1, fn2, ...)</code>. Use functions-first
+      only when you need a reusable pipeline.
     </p>
 
     <CodeBlock
       language="typescript"
       code={`import { pipeAsync } from 'fp-pack';
 
-const fn = pipeAsync(
+const result = await pipeAsync(
+  2,
   async (n: number) => n + 1,
   async (n) => n * 2
-);
-
-const result = await fn(2); // 6`}
+); // 6`}
     />
 
     <hr class="border-t border-gray-200 dark:border-gray-700 my-10" />
@@ -54,9 +54,7 @@ const result = await fn(2); // 6`}
 const fetchUser = async (id: string) => ({ id, name: 'Ada' });
 const getName = (u: { name: string }) => u.name;
 
-const getUserName = pipeAsync(fetchUser, getName);
-
-await getUserName('42'); // 'Ada'`}
+const result = await pipeAsync('42', fetchUser, getName); // 'Ada'`}
     />
 
     <hr class="border-t border-gray-200 dark:border-gray-700 my-10" />

--- a/docs/src/pages/PipeAsyncSideEffectStrict.tsx
+++ b/docs/src/pages/PipeAsyncSideEffectStrict.tsx
@@ -22,20 +22,20 @@ export const PipeAsyncSideEffectStrict = () => (
         pipeAsyncSideEffectStrict
       </strong>{' '}
       is the async strict variant of <strong>pipeAsyncSideEffect</strong>. It preserves a precise union of SideEffect
-      result types while still short-circuiting the pipeline.
+      result types while still short-circuiting the pipeline. Prefer value-first
+      <code class="text-sm">pipeAsyncSideEffectStrict(data, ...)</code> for inference.
     </p>
 
     <CodeBlock
       language="typescript"
       code={`import { pipeAsyncSideEffectStrict, SideEffect } from 'fp-pack';
 
-const pipeline = pipeAsyncSideEffectStrict(
+// Result type: Promise<number | SideEffect<'NEGATIVE' | 0>>
+const result = await pipeAsyncSideEffectStrict(
+  5,
   async (n: number) => (n > 0 ? n : SideEffect.of(() => 'NEGATIVE' as const)),
   (n) => (n > 10 ? n : SideEffect.of(() => 0 as const))
-);
-
-// Result type: Promise<number | SideEffect<'NEGATIVE' | 0>>
-const result = await pipeline(5);`}
+);`}
     />
 
     <div class="bg-amber-50 dark:bg-amber-900/20 p-4 mb-6 rounded border border-amber-200 dark:border-amber-800 mt-6">
@@ -58,6 +58,11 @@ const result = await pipeline(5);`}
     <CodeBlock
       language="typescript"
       code={`function pipeAsyncSideEffectStrict<A, R>(
+  a: A,
+  ab: (a: A) => R | SideEffect | Promise<R | SideEffect>
+): Promise<R | SideEffect<UnionOfAllEffects>>;
+
+function pipeAsyncSideEffectStrict<A, R>(
   ab: (a: A) => R | SideEffect | Promise<R | SideEffect>
 ): (a: A | SideEffect) => Promise<R | SideEffect<UnionOfAllEffects>>;`}
     />

--- a/docs/src/pages/PipeAsyncSideEffectStrict_ko.tsx
+++ b/docs/src/pages/PipeAsyncSideEffectStrict_ko.tsx
@@ -22,20 +22,20 @@ export const PipeAsyncSideEffectStrict_ko = () => (
         pipeAsyncSideEffectStrict
       </strong>{' '}
       는 <strong>pipeAsyncSideEffect</strong>의 엄격 버전입니다. SideEffect 결과 타입을 정확한 유니온으로 유지하면서
-      파이프라인을 단락(short-circuit)합니다.
+      파이프라인을 단락(short-circuit)합니다. 타입 추론을 위해
+      <code class="text-sm">pipeAsyncSideEffectStrict(data, ...)</code> 형태를 우선 사용하세요.
     </p>
 
     <CodeBlock
       language="typescript"
       code={`import { pipeAsyncSideEffectStrict, SideEffect } from 'fp-pack';
 
-const pipeline = pipeAsyncSideEffectStrict(
+// 결과 타입: Promise<number | SideEffect<'NEGATIVE' | 0>>
+const result = await pipeAsyncSideEffectStrict(
+  5,
   async (n: number) => (n > 0 ? n : SideEffect.of(() => 'NEGATIVE' as const)),
   (n) => (n > 10 ? n : SideEffect.of(() => 0 as const))
-);
-
-// 결과 타입: Promise<number | SideEffect<'NEGATIVE' | 0>>
-const result = await pipeline(5);`}
+);`}
     />
 
     <div class="bg-amber-50 dark:bg-amber-900/20 p-4 mb-6 rounded border border-amber-200 dark:border-amber-800 mt-6">
@@ -59,6 +59,11 @@ const result = await pipeline(5);`}
     <CodeBlock
       language="typescript"
       code={`function pipeAsyncSideEffectStrict<A, R>(
+  a: A,
+  ab: (a: A) => R | SideEffect | Promise<R | SideEffect>
+): Promise<R | SideEffect<UnionOfAllEffects>>;
+
+function pipeAsyncSideEffectStrict<A, R>(
   ab: (a: A) => R | SideEffect | Promise<R | SideEffect>
 ): (a: A | SideEffect) => Promise<R | SideEffect<UnionOfAllEffects>>;`}
     />

--- a/docs/src/pages/PipeAsync_ko.tsx
+++ b/docs/src/pages/PipeAsync_ko.tsx
@@ -8,7 +8,7 @@ export const PipeAsync_ko = () => (
     </h1>
 
     <p class="text-lg text-gray-600 dark:text-gray-400 mb-8">
-      비동기/동기 함수를 좌→우로 합성해 새로운 함수를 반환합니다
+      비동기/동기 함수를 좌→우로 합성하며 value-first 또는 함수-우선 호출을 지원합니다
     </p>
 
     <hr class="border-t border-gray-200 dark:border-gray-700 my-10" />
@@ -21,20 +21,19 @@ export const PipeAsync_ko = () => (
       <strong class="font-semibold text-blue-700 dark:text-blue-300 bg-blue-100 dark:bg-blue-900/20 px-2 py-1 rounded">
         pipeAsync
       </strong>{' '}
-      는 비동기/동기 함수를 받아 새로운 함수를 만듭니다. 호출하면 각 스텝을 순서대로 실행하며 필요한 곳에서 await합니다.
-      시그니처: <code>pipeAsync(fn1, fn2, ...)(value)</code>.
+      는 비동기/동기 함수를 받아 순서대로 실행하며 필요한 곳에서 await합니다. 타입 추론을 위해 value-first를 권장합니다.
+      시그니처: <code>pipeAsync(value, fn1, fn2, ...)</code>. 재사용이 필요할 때만 함수-우선을 사용하세요.
     </p>
 
     <CodeBlock
       language="typescript"
       code={`import { pipeAsync } from 'fp-pack';
 
-const fn = pipeAsync(
+const result = await pipeAsync(
+  2,
   async (n: number) => n + 1,
   async (n) => n * 2
-);
-
-const result = await fn(2); // 6`}
+); // 6`}
     />
 
     <hr class="border-t border-gray-200 dark:border-gray-700 my-10" />
@@ -54,9 +53,7 @@ const result = await fn(2); // 6`}
 const fetchUser = async (id: string) => ({ id, name: 'Ada' });
 const getName = (u: { name: string }) => u.name;
 
-const getUserName = pipeAsync(fetchUser, getName);
-
-await getUserName('42'); // 'Ada'`}
+const result = await pipeAsync('42', fetchUser, getName); // 'Ada'`}
     />
 
     <hr class="border-t border-gray-200 dark:border-gray-700 my-10" />

--- a/docs/src/pages/PipeSideEffectStrict.tsx
+++ b/docs/src/pages/PipeSideEffectStrict.tsx
@@ -22,20 +22,20 @@ export const PipeSideEffectStrict = () => (
         pipeSideEffectStrict
       </strong>{' '}
       is the strict counterpart of <strong>pipeSideEffect</strong>. It keeps a precise union of all SideEffect result
-      types across the pipeline so TypeScript can narrow errors more accurately.
+      types across the pipeline so TypeScript can narrow errors more accurately. Prefer value-first
+      <code class="text-sm">pipeSideEffectStrict(data, ...)</code> for inference, and use function-first for reuse.
     </p>
 
     <CodeBlock
       language="typescript"
       code={`import { pipeSideEffectStrict, SideEffect } from 'fp-pack';
 
-const pipeline = pipeSideEffectStrict(
+// Result type: number | SideEffect<'NEGATIVE' | 0>
+const result = pipeSideEffectStrict(
+  5,
   (n: number) => (n > 0 ? n : SideEffect.of(() => 'NEGATIVE' as const)),
   (n) => (n > 10 ? n : SideEffect.of(() => 0 as const))
-);
-
-// Result type: number | SideEffect<'NEGATIVE' | 0>
-const result = pipeline(5);`}
+);`}
     />
 
     <div class="bg-amber-50 dark:bg-amber-900/20 p-4 mb-6 rounded border border-amber-200 dark:border-amber-800 mt-6">
@@ -58,6 +58,11 @@ const result = pipeline(5);`}
     <CodeBlock
       language="typescript"
       code={`function pipeSideEffectStrict<A, R>(
+  a: A,
+  ab: (a: A) => R | SideEffect
+): R | SideEffect<UnionOfAllEffects>;
+
+function pipeSideEffectStrict<A, R>(
   ab: (a: A) => R | SideEffect
 ): (a: A | SideEffect) => R | SideEffect<UnionOfAllEffects>;`}
     />

--- a/docs/src/pages/PipeSideEffectStrict_ko.tsx
+++ b/docs/src/pages/PipeSideEffectStrict_ko.tsx
@@ -22,20 +22,20 @@ export const PipeSideEffectStrict_ko = () => (
         pipeSideEffectStrict
       </strong>{' '}
       는 <strong>pipeSideEffect</strong>의 엄격 버전입니다. 파이프라인에서 발생 가능한 SideEffect 결과 타입을
-      정확하게 유니온으로 유지하여 더 정밀한 타입 내로잉이 가능합니다.
+      정확하게 유니온으로 유지하여 더 정밀한 타입 내로잉이 가능합니다. 타입 추론을 위해
+      <code class="text-sm">pipeSideEffectStrict(data, ...)</code> 형태를 우선 사용하세요.
     </p>
 
     <CodeBlock
       language="typescript"
       code={`import { pipeSideEffectStrict, SideEffect } from 'fp-pack';
 
-const pipeline = pipeSideEffectStrict(
+// 결과 타입: number | SideEffect<'NEGATIVE' | 0>
+const result = pipeSideEffectStrict(
+  5,
   (n: number) => (n > 0 ? n : SideEffect.of(() => 'NEGATIVE' as const)),
   (n) => (n > 10 ? n : SideEffect.of(() => 0 as const))
-);
-
-// 결과 타입: number | SideEffect<'NEGATIVE' | 0>
-const result = pipeline(5);`}
+);`}
     />
 
     <div class="bg-amber-50 dark:bg-amber-900/20 p-4 mb-6 rounded border border-amber-200 dark:border-amber-800 mt-6">
@@ -59,6 +59,11 @@ const result = pipeline(5);`}
     <CodeBlock
       language="typescript"
       code={`function pipeSideEffectStrict<A, R>(
+  a: A,
+  ab: (a: A) => R | SideEffect
+): R | SideEffect<UnionOfAllEffects>;
+
+function pipeSideEffectStrict<A, R>(
   ab: (a: A) => R | SideEffect
 ): (a: A | SideEffect) => R | SideEffect<UnionOfAllEffects>;`}
     />

--- a/docs/src/pages/PipeSideEffect_ko.tsx
+++ b/docs/src/pages/PipeSideEffect_ko.tsx
@@ -24,7 +24,8 @@ export const PipeSideEffect_ko = () => (
       는 <strong>pipe</strong>처럼 함수를 왼쪽에서 오른쪽으로 합성하지만,
       <strong class="font-semibold">SideEffect</strong>를 반환하면 즉시 중단하고 그대로 반환합니다.
       입력으로 SideEffect를 받으면 실행 없이 그대로 돌려줍니다.
-      순수 파이프라인은 <strong>pipe</strong>를 사용하세요.
+      타입 추론을 위해 <code class="text-sm">pipeSideEffect(data, ...)</code> 형태를 우선 사용하고,
+      재사용이 필요하면 함수만 넘기는 방식으로 구성하세요. 순수 파이프라인은 <strong>pipe</strong>를 사용하세요.
     </p>
 
     <CodeBlock
@@ -38,14 +39,15 @@ const validateAge = (age: number) =>
         throw new Error('18세 이상만 가능합니다');
       });
 
-const processAgePipeline = pipeSideEffect(
-  validateAge,
-  (age: number) => age * 2,
-  (age: number) => \`나이: \${age}\`
-);
-
 // runPipeResult는 파이프라인 밖에서 호출해야 합니다
-runPipeResult(processAgePipeline(15)); // Throws: Error: 18세 이상만 가능합니다`}
+runPipeResult(
+  pipeSideEffect(
+    15,
+    validateAge,
+    (age: number) => age * 2,
+    (age: number) => \`나이: \${age}\`
+  )
+); // Throws: Error: 18세 이상만 가능합니다`}
     />
 
     <div class="bg-green-50 dark:bg-green-900/20 p-4 mb-6 rounded border border-green-200 dark:border-green-800 mt-6">
@@ -69,6 +71,7 @@ runPipeResult(processAgePipeline(15)); // Throws: Error: 18세 이상만 가능�
 import { pipe, map, filter } from 'fp-pack';
 
 const processData = pipe(
+  users,
   filter(isValid),
   map(transform)
 );
@@ -76,10 +79,13 @@ const processData = pipe(
 // ✅ 좋음: SideEffect가 필요할 때만 - pipeSideEffect 사용
 import { pipeSideEffect, SideEffect } from 'fp-pack';
 
-const processWithValidation = pipeSideEffect(
-  validateOrStop,  // SideEffect를 반환할 수 있음
-  transform,
-  save
+const result = runPipeResult(
+  pipeSideEffect(
+    input,
+    validateOrStop,  // SideEffect를 반환할 수 있음
+    transform,
+    save
+  )
 );`}
     />
 
@@ -92,8 +98,19 @@ const processWithValidation = pipeSideEffect(
     <CodeBlock
       language="typescript"
       code={`function pipeSideEffect<A, R>(
+  a: A,
+  ab: (a: A) => R | SideEffect
+): R | SideEffect;
+
+function pipeSideEffect<A, R>(
   ab: (a: A) => R | SideEffect
 ): (a: A | SideEffect) => R | SideEffect;
+
+function pipeSideEffect<A, B, R>(
+  a: A,
+  ab: (a: A) => B | SideEffect,
+  bc: (b: B) => R | SideEffect
+): R | SideEffect;
 
 function pipeSideEffect<A, B, R>(
   ab: (a: A) => B | SideEffect,
@@ -120,13 +137,12 @@ function pipeSideEffect(...funcs: Array<(input: any) => any>): (input: any) => a
       language="typescript"
       code={`import { pipeSideEffectStrict, SideEffect } from 'fp-pack';
 
-const pipeline = pipeSideEffectStrict(
+// 결과 타입: number | SideEffect<'NEGATIVE' | 0>
+const result = pipeSideEffectStrict(
+  5,
   (n: number) => (n > 0 ? n : SideEffect.of(() => 'NEGATIVE' as const)),
   (n) => (n > 10 ? n : SideEffect.of(() => 0 as const))
-);
-
-// 결과 타입: number | SideEffect<'NEGATIVE' | 0>
-const result = pipeline(5);`}
+);`}
     />
 
     <div class="border-l-4 border-red-500 bg-red-50 dark:bg-red-900/20 p-4 mb-6 rounded-r mt-6">
@@ -181,21 +197,29 @@ const validateAge = (age: number) => {
   return age;
 };
 
-const processAgePipeline = pipeSideEffect(
-  validateAge,
-  (age: number) => age * 2,  // SideEffect가 반환되면 실행되지 않음
-  (age: number) => \`나이: \${age}\`
-);
-
 // runPipeResult는 파이프라인 밖에서 호출해야 합니다
 try {
-  runPipeResult(processAgePipeline(-5));  // Throws: Error: 나이는 음수일 수 없습니다
+  runPipeResult(
+    pipeSideEffect(
+      -5,
+      validateAge,
+      (age: number) => age * 2,  // SideEffect가 반환되면 실행되지 않음
+      (age: number) => \`나이: \${age}\`
+    )
+  );  // Throws: Error: 나이는 음수일 수 없습니다
 } catch (error) {
   console.error(error.message);
 }
 
 // 정상 실행 계속
-const result = runPipeResult(processAgePipeline(10));
+const result = runPipeResult(
+  pipeSideEffect(
+    10,
+    validateAge,
+    (age: number) => age * 2,
+    (age: number) => \`나이: \${age}\`
+  )
+);
 console.log(result);  // "나이: 20"`}
     />
 
@@ -223,24 +247,34 @@ const checkPermission = (user: User) => {
   return user;
 };
 
-const deleteUserPipeline = pipeSideEffect(
-  checkPermission,
-  (user: User) => {
-    console.log(\`사용자 삭제 중: \${user.name}\`);
-    return { success: true, deletedId: user.id };
-  }
-);
-
 const adminUser = { id: 1, name: 'Alice', role: 'admin' as const };
 const normalUser = { id: 2, name: 'Bob', role: 'user' as const };
 
 // 관리자는 진행 가능 - runPipeResult는 밖에서 호출
-const result1 = runPipeResult(deleteUserPipeline(adminUser));
+const result1 = runPipeResult(
+  pipeSideEffect(
+    adminUser,
+    checkPermission,
+    (user: User) => {
+      console.log(\`사용자 삭제 중: \${user.name}\`);
+      return { success: true, deletedId: user.id };
+    }
+  )
+);
 // 로그: "사용자 삭제 중: Alice"
 console.log(result1);  // { success: true, deletedId: 1 }
 
 // 일반 사용자는 즉시 에러 반환
-const result2 = runPipeResult(deleteUserPipeline(normalUser));
+const result2 = runPipeResult(
+  pipeSideEffect(
+    normalUser,
+    checkPermission,
+    (user: User) => {
+      console.log(\`사용자 삭제 중: \${user.name}\`);
+      return { success: true, deletedId: user.id };
+    }
+  )
+);
 console.log(result2);  // { error: '권한 없음', message: '관리자 권한이 필요합니다' }`}
     />
 
@@ -262,18 +296,26 @@ const divide = (a: number, b: number) => {
   return a / b;
 };
 
-const calculatePipeline = pipeSideEffect(
-  (input: { a: number; b: number }) => divide(input.a, input.b),
-  (result: number) => result * 100,
-  (result: number) => Math.round(result)
-);
-
 // 정상 계산 - runPipeResult는 밖에서 호출
-const result1 = runPipeResult(calculatePipeline({ a: 10, b: 2 }));
+const result1 = runPipeResult(
+  pipeSideEffect(
+    { a: 10, b: 2 },
+    (input: { a: number; b: number }) => divide(input.a, input.b),
+    (result: number) => result * 100,
+    (result: number) => Math.round(result)
+  )
+);
 console.log(result1);  // 500
 
 // 0으로 나누기는 SideEffect를 실행하고 로그를 출력
-const result2 = runPipeResult(calculatePipeline({ a: 10, b: 0 }));
+const result2 = runPipeResult(
+  pipeSideEffect(
+    { a: 10, b: 0 },
+    (input: { a: number; b: number }) => divide(input.a, input.b),
+    (result: number) => result * 100,
+    (result: number) => Math.round(result)
+  )
+);
 // 로그: "0으로 나눌 수 없습니다!"
 console.log(result2);  // NaN`}
     />
@@ -324,14 +366,18 @@ const validateUserPipeline = pipeSideEffect(
 );
 // 결과 타입: User | SideEffect
 
+const userId = 1;
+
 // ❌ 잘못된 방법 - pipe는 SideEffect를 처리 못함
 const wrongPipeline = pipe(
+  userId,
   validateUserPipeline,  // User | SideEffect 반환
   (user) => user.email   // 타입 에러! SideEffect에는 'email' 프로퍼티가 없음
 );
 
 // ✅ 올바른 방법 - pipeSideEffect 계속 사용
 const correctPipeline = pipeSideEffect(
+  userId,
   validateUserPipeline,  // User | SideEffect - 올바르게 처리됨
   (user) => user.email,  // SideEffect면 자동으로 건너뜀
   sendEmail

--- a/docs/src/pages/Pipe_ko.tsx
+++ b/docs/src/pages/Pipe_ko.tsx
@@ -28,6 +28,8 @@ export const Pipe_ko = () => (
       <br />
       <br />
       변환을 읽는 가장 자연스러운 방법입니다: 데이터로 시작한 다음 변환을 순서대로 적용합니다.
+      타입 추론을 위해 value-first <code class="text-xs">pipe(value, ...)</code>를 우선 사용하고,
+      재사용이 필요할 때만 함수-우선 형태를 사용하세요.
     </p>
 
     <CodeBlock
@@ -38,13 +40,14 @@ const double = (n: number) => n * 2;
 const addTen = (n: number) => n + 10;
 const toString = (n: number) => String(n);
 
-const transform = pipe(
+const result = pipe(
+  5,
   double,    // 1. 먼저 숫자를 2배로
   addTen,    // 2. 그 다음 10을 더하고
   toString   // 3. 마지막으로 문자열로 변환
 );
 
-transform(5);  // "20"
+result;  // "20"
 // 흐름: 5 → double → 10 → addTen → 20 → toString → "20"`}
     />
 
@@ -62,14 +65,15 @@ transform(5);  // "20"
       language="typescript"
       code={`import { pipe } from 'fp-pack';
 
-const processName = pipe(
+const result = pipe(
+  '  John Doe  ',
   (name: string) => name.trim(),
   (name: string) => name.toLowerCase(),
   (name: string) => name.split(' '),
   (parts: string[]) => parts.join('-')
 );
 
-processName('  John Doe  ');  // "john-doe"`}
+result;  // "john-doe"`}
     />
 
     <h3 class="text-xl md:text-2xl font-medium text-gray-900 dark:text-white mb-4 mt-6">
@@ -82,13 +86,14 @@ processName('  John Doe  ');  // "john-doe"`}
 
 const numbers = [1, 2, 3, 4, 5];
 
-const processNumbers = pipe(
+const result = pipe(
+  numbers,
   (nums: number[]) => nums.filter(n => n > 2),
   (nums: number[]) => nums.map(n => n * 2),
   (nums: number[]) => nums.reduce((sum, n) => sum + n, 0)
 );
 
-processNumbers(numbers);  // 24
+result;  // 24
 // 흐름: [1,2,3,4,5] → filter → [3,4,5] → map → [6,8,10] → reduce → 24`}
     />
 
@@ -113,13 +118,6 @@ interface User {
   active: boolean;
 }
 
-const getActiveAdultNames = pipe(
-  (users: User[]) => users.filter(u => u.active),
-  (users: User[]) => users.filter(u => u.age >= 18),
-  (users: User[]) => users.map(u => u.name),
-  (names: string[]) => names.sort()
-);
-
 const users: User[] = [
   { id: 1, name: 'Alice', age: 25, active: true },
   { id: 2, name: 'Bob', age: 17, active: true },
@@ -127,7 +125,15 @@ const users: User[] = [
   { id: 4, name: 'Diana', age: 22, active: true },
 ];
 
-getActiveAdultNames(users);  // ["Alice", "Diana"]`}
+const result = pipe(
+  users,
+  (users: User[]) => users.filter(u => u.active),
+  (users: User[]) => users.filter(u => u.age >= 18),
+  (users: User[]) => users.map(u => u.name),
+  (names: string[]) => names.sort()
+);
+
+result;  // ["Alice", "Diana"]`}
     />
 
     <h3 class="text-xl md:text-2xl font-medium text-gray-900 dark:text-white mb-4 mt-6">
@@ -138,14 +144,15 @@ getActiveAdultNames(users);  // ["Alice", "Diana"]`}
       language="typescript"
       code={`import { pipe } from 'fp-pack';
 
-const calculateFinalPrice = pipe(
+const result = pipe(
+  100,
   (price: number) => price * 0.9,        // 10% 할인
   (price: number) => price * 1.1,        // 10% 세금 추가
   (price: number) => Math.round(price * 100) / 100,  // 소수점 2자리로
   (price: number) => \`₩\${price.toFixed(2)}\`  // 통화 형식으로
 );
 
-calculateFinalPrice(100);  // "₩99.00"`}
+result;  // "₩99.00"`}
     />
 
     <hr class="border-t border-gray-200 dark:border-gray-700 my-10" />
@@ -168,13 +175,14 @@ const add = curry((a: number, b: number) => a + b);
 const divide = curry((a: number, b: number) => a / b);
 
 // 파이프라인에서 조합
-const calculate = pipe(
+const result = pipe(
+  5,
   multiply(2),      // 2배로
   add(10),          // 10 더하기
   divide(4)         // 4로 나누기
 );
 
-calculate(5);  // 5
+result;  // 5
 // 흐름: 5 → *2 → 10 → +10 → 20 → /4 → 5`}
     />
 
@@ -196,10 +204,11 @@ calculate(5);  // 5
         <CodeBlock
           language="typescript"
           code={`pipe(
+  5,
   double,
   addTen,
   toString
-)(5)
+);
 // 5 → 10 → 20 → "20"`}
         />
       </div>

--- a/docs/src/pages/RunPipeResult.tsx
+++ b/docs/src/pages/RunPipeResult.tsx
@@ -38,12 +38,6 @@ const validateAge = (age: number) =>
         return null;
       });
 
-const processAgePipeline = pipeSideEffect(
-  validateAge,
-  (age) => age * 2,
-  (age) => \`Age: \${age}\`
-);
-
 // ❌ WRONG - Never call runPipeResult INSIDE a pipeline
 const wrongPipeline = pipeSideEffect(
   validateAge,
@@ -51,7 +45,14 @@ const wrongPipeline = pipeSideEffect(
 );
 
 // ✅ CORRECT - Call runPipeResult OUTSIDE the pipeline
-const result = runPipeResult(processAgePipeline(15));
+const result = runPipeResult(
+  pipeSideEffect(
+    15,
+    validateAge,
+    (age) => age * 2,
+    (age) => \`Age: \${age}\`
+  )
+);
 // Logs "Age validation failed", returns null`}
     />
 

--- a/docs/src/pages/RunPipeResult_ko.tsx
+++ b/docs/src/pages/RunPipeResult_ko.tsx
@@ -38,12 +38,6 @@ const validateAge = (age: number) =>
         return null;
       });
 
-const processAgePipeline = pipeSideEffect(
-  validateAge,
-  (age) => age * 2,
-  (age) => \`나이: \${age}\`
-);
-
 // ❌ 잘못됨 - 파이프라인 안에서 runPipeResult 호출하지 마세요
 const wrongPipeline = pipeSideEffect(
   validateAge,
@@ -51,7 +45,14 @@ const wrongPipeline = pipeSideEffect(
 );
 
 // ✅ 올바름 - 파이프라인 밖에서 runPipeResult 호출
-const result = runPipeResult(processAgePipeline(15));
+const result = runPipeResult(
+  pipeSideEffect(
+    15,
+    validateAge,
+    (age) => age * 2,
+    (age) => \`나이: \${age}\`
+  )
+);
 // "나이 검증 실패" 로그, null 반환`}
     />
 

--- a/docs/src/pages/SideEffect.tsx
+++ b/docs/src/pages/SideEffect.tsx
@@ -24,6 +24,7 @@ export const SideEffect = () => (
       is a container that wraps an effect (function) for deferred execution. When a function in a pipeSideEffect/pipeAsyncSideEffect returns a SideEffect,
       the pipeline immediately stops and returns the SideEffect without executing it. The effect only runs when you explicitly
       call <code class="text-sm">runPipeResult()</code> or <code class="text-sm">sideEffect.effect()</code>.
+      Prefer value-first <code class="text-sm">pipeSideEffect(data, ...)</code> for inference when composing pipelines.
       This pattern enables clean error handling and early termination in functional pipelines without wrapper types everywhere.
     </p>
 
@@ -40,14 +41,15 @@ const validateAge = (age: number) =>
         return null;
       });
 
-const processAgePipeline = pipeSideEffect(
-  validateAge,
-  (age) => age * 2,      // Skipped if SideEffect returned
-  (age) => \`Age: \${age}\`
-);
-
 // runPipeResult must be called OUTSIDE the pipeline
-runPipeResult(processAgePipeline(15)); // Logs "Age validation failed", returns null`}
+runPipeResult(
+  pipeSideEffect(
+    15,
+    validateAge,
+    (age) => age * 2,      // Skipped if SideEffect returned
+    (age) => \`Age: \${age}\`
+  )
+); // Logs "Age validation failed", returns null`}
     />
 
     <div class="bg-green-50 dark:bg-green-900/20 p-4 mb-6 rounded border border-green-200 dark:border-green-800 mt-6">

--- a/docs/src/pages/SideEffect_ko.tsx
+++ b/docs/src/pages/SideEffect_ko.tsx
@@ -24,6 +24,7 @@ export const SideEffect_ko = () => (
       는 지연 실행을 위해 effect(함수)를 감싸는 컨테이너입니다. pipeSideEffect/pipeAsyncSideEffect 내 함수가 SideEffect를 반환하면,
       파이프라인은 즉시 중단되고 실행하지 않은 채로 SideEffect를 반환합니다. effect는 명시적으로
       <code class="text-sm">runPipeResult()</code> 또는 <code class="text-sm">sideEffect.effect()</code>를 호출할 때만 실행됩니다.
+      타입 추론을 위해 <code class="text-sm">pipeSideEffect(data, ...)</code> 형태를 우선 사용하세요.
       이 패턴은 모든 곳에 래퍼 타입을 사용하지 않고도 함수형 파이프라인에서 깔끔한 에러 처리와 조기 종료를 가능하게 합니다.
     </p>
 
@@ -40,14 +41,15 @@ const validateAge = (age: number) =>
         return null;
       });
 
-const processAgePipeline = pipeSideEffect(
-  validateAge,
-  (age) => age * 2,      // SideEffect 반환 시 건너뜀
-  (age) => \`나이: \${age}\`
-);
-
 // runPipeResult는 파이프라인 밖에서 호출해야 합니다
-runPipeResult(processAgePipeline(15)); // "나이 검증 실패" 로그, null 반환`}
+runPipeResult(
+  pipeSideEffect(
+    15,
+    validateAge,
+    (age) => age * 2,      // SideEffect 반환 시 건너뜀
+    (age) => \`나이: \${age}\`
+  )
+); // "나이 검증 실패" 로그, null 반환`}
     />
 
     <div class="bg-green-50 dark:bg-green-900/20 p-4 mb-6 rounded border border-green-200 dark:border-green-800 mt-6">

--- a/docs/src/pages/TypeUsage.tsx
+++ b/docs/src/pages/TypeUsage.tsx
@@ -151,28 +151,34 @@ const filteredUsers = filterUsers(users);
     </p>
 
     <p class="text-sm md:text-base text-gray-700 dark:text-gray-300 leading-relaxed mb-6">
-      Use one of these workarounds: <code class="px-2 py-1 bg-gray-100 dark:bg-gray-800 rounded text-sm">pipeHint</code>,
-      a data-first wrapper, or an explicit type annotation for the curried function.
+      Use one of these workarounds: value-first input to anchor types,{' '}
+      <code class="px-2 py-1 bg-gray-100 dark:bg-gray-800 rounded text-sm">pipeHint</code>, or an explicit type annotation
+      for the curried function.
     </p>
 
     <CodeBlock
       language="typescript"
       code={`import { pipe, pipeHint, zip, some } from 'fp-pack';
 
-// Option 1: data-first wrapper
+const values = [4, 5, 6];
+
+// Option 1: value-first input
 const withWrapper = pipe(
+  values,
   (values: number[]) => zip([1, 2, 3], values),
   some(([a, b]) => a > b)
 );
 
 // Option 2: explicit type annotation
 const withHint = pipe(
+  values,
   zip([1, 2, 3]) as (values: number[]) => Array<[number, number]>,
   some(([a, b]) => a > b)
 );
 
 // Option 3: pipeHint helper
 const withPipeHint = pipe(
+  values,
   pipeHint<number[], Array<[number, number]>>(zip([1, 2, 3])),
   some(([a, b]) => a > b)
 );`}
@@ -196,7 +202,7 @@ const withPipeHint = pipe(
     </h2>
 
     <p class="text-sm md:text-base text-gray-700 dark:text-gray-300 leading-relaxed mb-6">
-      The <code class="px-2 py-1 bg-gray-100 dark:bg-gray-800 rounded text-sm">FromFn</code> type represents functions created with the <code class="px-2 py-1 bg-gray-100 dark:bg-gray-800 rounded text-sm">from</code> utility. When used as the first function in a pipeline, it allows the pipeline to be called without an initial input value, enabling cleaner data-first patterns.
+      The <code class="px-2 py-1 bg-gray-100 dark:bg-gray-800 rounded text-sm">FromFn</code> type represents functions created with the <code class="px-2 py-1 bg-gray-100 dark:bg-gray-800 rounded text-sm">from</code> utility. When used as the first function in a pipeline, it allows the pipeline to be called without an initial input value. If you already have data, prefer <code class="px-2 py-1 bg-gray-100 dark:bg-gray-800 rounded text-sm">pipe(data, ...)</code>.
     </p>
 
     <h3 class="text-xl md:text-2xl font-medium text-gray-900 dark:text-white mb-3">

--- a/docs/src/pages/TypeUsage_ko.tsx
+++ b/docs/src/pages/TypeUsage_ko.tsx
@@ -151,28 +151,33 @@ const filteredUsers = filterUsers(users);
     </p>
 
     <p class="text-sm md:text-base text-gray-700 dark:text-gray-300 leading-relaxed mb-6">
-      해결책은 <code class="px-2 py-1 bg-gray-100 dark:bg-gray-800 rounded text-sm">pipeHint</code>,
-      data-first 래핑, 또는 커리 함수의 명시적 타입 힌트/캐스팅입니다.
+      해결책은 데이터 값을 먼저 넘겨 타입을 고정하는 방법, <code class="px-2 py-1 bg-gray-100 dark:bg-gray-800 rounded text-sm">pipeHint</code>,
+      또는 커리 함수의 명시적 타입 힌트/캐스팅입니다.
     </p>
 
     <CodeBlock
       language="typescript"
       code={`import { pipe, pipeHint, zip, some } from 'fp-pack';
 
-// 방법 1: data-first 래핑
+const values = [4, 5, 6];
+
+// 방법 1: 값 먼저 전달 (value-first)
 const withWrapper = pipe(
+  values,
   (values: number[]) => zip([1, 2, 3], values),
   some(([a, b]) => a > b)
 );
 
 // 방법 2: 명시적 타입 힌트
 const withHint = pipe(
+  values,
   zip([1, 2, 3]) as (values: number[]) => Array<[number, number]>,
   some(([a, b]) => a > b)
 );
 
 // 방법 3: pipeHint 헬퍼
 const withPipeHint = pipe(
+  values,
   pipeHint<number[], Array<[number, number]>>(zip([1, 2, 3])),
   some(([a, b]) => a > b)
 );`}
@@ -196,7 +201,7 @@ const withPipeHint = pipe(
     </h2>
 
     <p class="text-sm md:text-base text-gray-700 dark:text-gray-300 leading-relaxed mb-6">
-      <code class="px-2 py-1 bg-gray-100 dark:bg-gray-800 rounded text-sm">FromFn</code> 타입은 <code class="px-2 py-1 bg-gray-100 dark:bg-gray-800 rounded text-sm">from</code> 유틸리티로 생성된 함수를 나타냅니다. 파이프라인의 첫 번째 함수로 사용될 때 초기 입력 값 없이 파이프라인을 호출할 수 있어 더 깔끔한 데이터 우선 패턴을 가능하게 합니다.
+      <code class="px-2 py-1 bg-gray-100 dark:bg-gray-800 rounded text-sm">FromFn</code> 타입은 <code class="px-2 py-1 bg-gray-100 dark:bg-gray-800 rounded text-sm">from</code> 유틸리티로 생성된 함수를 나타냅니다. 파이프라인의 첫 번째 함수로 사용될 때 초기 입력 값 없이 파이프라인을 호출할 수 있습니다. 이미 값이 있다면 <code class="px-2 py-1 bg-gray-100 dark:bg-gray-800 rounded text-sm">pipe(data, ...)</code>를 우선 사용하세요.
     </p>
 
     <h3 class="text-xl md:text-2xl font-medium text-gray-900 dark:text-white mb-3">

--- a/src/implement/async/pipeAsync.test.ts
+++ b/src/implement/async/pipeAsync.test.ts
@@ -11,6 +11,16 @@ describe('pipeAsync', () => {
     await expect(fn(2)).resolves.toBe(6);
   });
 
+  it('supports data-first invocation', async () => {
+    await expect(
+      pipeAsync(
+        2,
+        async (n: number) => n + 1,
+        (n) => n * 2
+      )
+    ).resolves.toBe(6);
+  });
+
   it('allows sync functions in the chain', async () => {
     const fn = pipeAsync(
       (n: number) => n + 1,

--- a/src/implement/async/pipeAsync.ts
+++ b/src/implement/async/pipeAsync.ts
@@ -7,6 +7,7 @@ type NoInfer<T> = [T][T extends any ? 0 : never];
 type AsyncOrSync<A, R> = (a: A) => R | Promise<R>;
 type ZeroFn<R> = () => R | Promise<R>;
 type AnyFn = (...args: any[]) => any;
+type NonFunction<T> = T extends AnyFn ? never : T;
 
 type FnInput<F> = F extends (a: infer A) => any ? A : never;
 type FnReturn<F> = F extends (...args: any[]) => infer R ? R : never;
@@ -48,6 +49,174 @@ type PipeAsync<Fns extends AsyncOrSync<any, any>[]> = (input: PipeInput<Fns>) =>
 type PipeAsyncFrom<Fns extends [FromFn<any>, ...AsyncOrSync<any, any>[]]> = (
   input?: PipeInput<Fns>
 ) => Promise<PipeOutput<Fns>>;
+
+type PipeCheckWithInput<Input, Fns extends [AnyFn, ...AnyFn[]]> =
+  Fns extends [infer F, ...infer Rest]
+    ? F extends AsyncOrSync<any, any>
+      ? Rest extends AnyFn[]
+        ? PipeCheck<[ValidateFn<F, Input>, ...Rest]>
+        : PipeCheck<[ValidateFn<F, Input>]>
+      : PipeError<Input, unknown>
+    : PipeError<unknown, unknown>;
+
+function pipeAsync<A>(input: NonFunction<A>): Promise<A>;
+function pipeAsync<A, F1 extends AsyncOrSync<A, any>>(
+  input: NonFunction<A>,
+  ab: ValidateFn<F1, A>
+): Promise<FnValue<F1>>;
+function pipeAsync<A, F1 extends AsyncOrSync<A, any>, F2 extends AsyncOrSync<FnValue<F1>, any>>(
+  input: NonFunction<A>,
+  ab: ValidateFn<F1, A>,
+  bc: ValidateFn<F2, FnValue<F1>>
+): Promise<FnValue<F2>>;
+function pipeAsync<
+  A,
+  F1 extends AsyncOrSync<A, any>,
+  F2 extends AsyncOrSync<FnValue<F1>, any>,
+  F3 extends AsyncOrSync<FnValue<F2>, any>
+>(
+  input: NonFunction<A>,
+  ab: ValidateFn<F1, A>,
+  bc: ValidateFn<F2, FnValue<F1>>,
+  cd: ValidateFn<F3, FnValue<F2>>
+): Promise<FnValue<F3>>;
+function pipeAsync<
+  A,
+  F1 extends AsyncOrSync<A, any>,
+  F2 extends AsyncOrSync<FnValue<F1>, any>,
+  F3 extends AsyncOrSync<FnValue<F2>, any>,
+  F4 extends AsyncOrSync<FnValue<F3>, any>
+>(
+  input: NonFunction<A>,
+  ab: ValidateFn<F1, A>,
+  bc: ValidateFn<F2, FnValue<F1>>,
+  cd: ValidateFn<F3, FnValue<F2>>,
+  de: ValidateFn<F4, FnValue<F3>>
+): Promise<FnValue<F4>>;
+function pipeAsync<
+  A,
+  F1 extends AsyncOrSync<A, any>,
+  F2 extends AsyncOrSync<FnValue<F1>, any>,
+  F3 extends AsyncOrSync<FnValue<F2>, any>,
+  F4 extends AsyncOrSync<FnValue<F3>, any>,
+  F5 extends AsyncOrSync<FnValue<F4>, any>
+>(
+  input: NonFunction<A>,
+  ab: ValidateFn<F1, A>,
+  bc: ValidateFn<F2, FnValue<F1>>,
+  cd: ValidateFn<F3, FnValue<F2>>,
+  de: ValidateFn<F4, FnValue<F3>>,
+  ef: ValidateFn<F5, FnValue<F4>>
+): Promise<FnValue<F5>>;
+function pipeAsync<
+  A,
+  F1 extends AsyncOrSync<A, any>,
+  F2 extends AsyncOrSync<FnValue<F1>, any>,
+  F3 extends AsyncOrSync<FnValue<F2>, any>,
+  F4 extends AsyncOrSync<FnValue<F3>, any>,
+  F5 extends AsyncOrSync<FnValue<F4>, any>,
+  F6 extends AsyncOrSync<FnValue<F5>, any>
+>(
+  input: NonFunction<A>,
+  ab: ValidateFn<F1, A>,
+  bc: ValidateFn<F2, FnValue<F1>>,
+  cd: ValidateFn<F3, FnValue<F2>>,
+  de: ValidateFn<F4, FnValue<F3>>,
+  ef: ValidateFn<F5, FnValue<F4>>,
+  fg: ValidateFn<F6, FnValue<F5>>
+): Promise<FnValue<F6>>;
+function pipeAsync<
+  A,
+  F1 extends AsyncOrSync<A, any>,
+  F2 extends AsyncOrSync<FnValue<F1>, any>,
+  F3 extends AsyncOrSync<FnValue<F2>, any>,
+  F4 extends AsyncOrSync<FnValue<F3>, any>,
+  F5 extends AsyncOrSync<FnValue<F4>, any>,
+  F6 extends AsyncOrSync<FnValue<F5>, any>,
+  F7 extends AsyncOrSync<FnValue<F6>, any>
+>(
+  input: NonFunction<A>,
+  ab: ValidateFn<F1, A>,
+  bc: ValidateFn<F2, FnValue<F1>>,
+  cd: ValidateFn<F3, FnValue<F2>>,
+  de: ValidateFn<F4, FnValue<F3>>,
+  ef: ValidateFn<F5, FnValue<F4>>,
+  fg: ValidateFn<F6, FnValue<F5>>,
+  gh: ValidateFn<F7, FnValue<F6>>
+): Promise<FnValue<F7>>;
+function pipeAsync<
+  A,
+  F1 extends AsyncOrSync<A, any>,
+  F2 extends AsyncOrSync<FnValue<F1>, any>,
+  F3 extends AsyncOrSync<FnValue<F2>, any>,
+  F4 extends AsyncOrSync<FnValue<F3>, any>,
+  F5 extends AsyncOrSync<FnValue<F4>, any>,
+  F6 extends AsyncOrSync<FnValue<F5>, any>,
+  F7 extends AsyncOrSync<FnValue<F6>, any>,
+  F8 extends AsyncOrSync<FnValue<F7>, any>
+>(
+  input: NonFunction<A>,
+  ab: ValidateFn<F1, A>,
+  bc: ValidateFn<F2, FnValue<F1>>,
+  cd: ValidateFn<F3, FnValue<F2>>,
+  de: ValidateFn<F4, FnValue<F3>>,
+  ef: ValidateFn<F5, FnValue<F4>>,
+  fg: ValidateFn<F6, FnValue<F5>>,
+  gh: ValidateFn<F7, FnValue<F6>>,
+  hi: ValidateFn<F8, FnValue<F7>>
+): Promise<FnValue<F8>>;
+function pipeAsync<
+  A,
+  F1 extends AsyncOrSync<A, any>,
+  F2 extends AsyncOrSync<FnValue<F1>, any>,
+  F3 extends AsyncOrSync<FnValue<F2>, any>,
+  F4 extends AsyncOrSync<FnValue<F3>, any>,
+  F5 extends AsyncOrSync<FnValue<F4>, any>,
+  F6 extends AsyncOrSync<FnValue<F5>, any>,
+  F7 extends AsyncOrSync<FnValue<F6>, any>,
+  F8 extends AsyncOrSync<FnValue<F7>, any>,
+  F9 extends AsyncOrSync<FnValue<F8>, any>
+>(
+  input: NonFunction<A>,
+  ab: ValidateFn<F1, A>,
+  bc: ValidateFn<F2, FnValue<F1>>,
+  cd: ValidateFn<F3, FnValue<F2>>,
+  de: ValidateFn<F4, FnValue<F3>>,
+  ef: ValidateFn<F5, FnValue<F4>>,
+  fg: ValidateFn<F6, FnValue<F5>>,
+  gh: ValidateFn<F7, FnValue<F6>>,
+  hi: ValidateFn<F8, FnValue<F7>>,
+  ij: ValidateFn<F9, FnValue<F8>>
+): Promise<FnValue<F9>>;
+function pipeAsync<
+  A,
+  F1 extends AsyncOrSync<A, any>,
+  F2 extends AsyncOrSync<FnValue<F1>, any>,
+  F3 extends AsyncOrSync<FnValue<F2>, any>,
+  F4 extends AsyncOrSync<FnValue<F3>, any>,
+  F5 extends AsyncOrSync<FnValue<F4>, any>,
+  F6 extends AsyncOrSync<FnValue<F5>, any>,
+  F7 extends AsyncOrSync<FnValue<F6>, any>,
+  F8 extends AsyncOrSync<FnValue<F7>, any>,
+  F9 extends AsyncOrSync<FnValue<F8>, any>,
+  F10 extends AsyncOrSync<FnValue<F9>, any>
+>(
+  input: NonFunction<A>,
+  ab: ValidateFn<F1, A>,
+  bc: ValidateFn<F2, FnValue<F1>>,
+  cd: ValidateFn<F3, FnValue<F2>>,
+  de: ValidateFn<F4, FnValue<F3>>,
+  ef: ValidateFn<F5, FnValue<F4>>,
+  fg: ValidateFn<F6, FnValue<F5>>,
+  gh: ValidateFn<F7, FnValue<F6>>,
+  hi: ValidateFn<F8, FnValue<F7>>,
+  ij: ValidateFn<F9, FnValue<F8>>,
+  jk: ValidateFn<F10, FnValue<F9>>
+): Promise<FnValue<F10>>;
+function pipeAsync<A, Fns extends [AsyncOrSync<any, any>, ...AsyncOrSync<any, any>[]]>(
+  input: NonFunction<A>,
+  ...funcs: PipeCheckWithInput<A, Fns>
+): Promise<PipeOutput<Fns>>;
 
 function pipeAsync<R>(ab: ZeroFn<R>): () => Promise<FnValue<ZeroFn<R>>>;
 function pipeAsync<B, F2 extends AsyncOrSync<FnValue<ZeroFn<B>>, any>>(
@@ -454,14 +623,25 @@ function pipeAsync<
 function pipeAsync<Fns extends [FromFn<any>, ...AsyncOrSync<any, any>[]]>(...funcs: PipeCheck<Fns>): PipeAsyncFrom<Fns>;
 function pipeAsync<Fns extends [AsyncOrSync<any, any>, ...AsyncOrSync<any, any>[]]>(...funcs: PipeCheck<Fns>): PipeAsync<Fns>;
 function pipeAsync(...funcs: Array<AsyncOrSync<any, any>>): (value: any) => Promise<any>;
-function pipeAsync(...funcs: Array<(arg: any) => any>) {
-  return async (value: any) => {
+function pipeAsync(...args: Array<any>) {
+  const run = async (value: any, funcs: Array<(arg: any) => any>) => {
     let acc = value;
     for (const fn of funcs) {
       acc = await fn(acc);
     }
     return acc;
   };
+
+  if (args.length === 0) {
+    return Promise.resolve(undefined);
+  }
+  const [input, ...rest] = args as [any, ...Array<(arg: any) => any>];
+  if (typeof input === 'function') {
+    const funcs = [input, ...rest];
+    return (value: any) => run(value, funcs);
+  }
+
+  return run(input, rest);
 }
 
 export default pipeAsync;

--- a/src/implement/async/pipeAsyncSideEffect.test.ts
+++ b/src/implement/async/pipeAsyncSideEffect.test.ts
@@ -14,6 +14,16 @@ describe('pipeAsyncSideEffect', () => {
     expect(result).toBe(effect);
   });
 
+  it('supports data-first invocation', async () => {
+    await expect(
+      pipeAsyncSideEffect(
+        2,
+        async (n: number) => n + 1,
+        (n) => n * 2
+      )
+    ).resolves.toBe(6);
+  });
+
   it('returns SideEffect inputs without executing the pipeline', async () => {
     const effect = new SideEffect(() => 'effect');
     const fn = pipeAsyncSideEffect(async (n: number) => n + 1);

--- a/src/implement/async/pipeAsyncSideEffect.ts
+++ b/src/implement/async/pipeAsyncSideEffect.ts
@@ -11,6 +11,7 @@ type AsyncOrSync<A, R> = (a: A) => MaybeSideEffect<R> | Promise<MaybeSideEffect<
 type FirstAsyncOrSync<A, R> = AsyncOrSync<A, R> & { __from?: never };
 type ZeroFn<R> = () => MaybeSideEffect<R> | Promise<MaybeSideEffect<R>>;
 type AnyFn = (...args: any[]) => any;
+type NonFunction<T> = T extends AnyFn ? never : T;
 
 type FnInput<F> = F extends (a: infer A) => any ? A : never;
 type FnReturn<F> = F extends (...args: any[]) => infer R ? R : never;
@@ -58,6 +59,174 @@ type PipeAsyncSideEffect<Fns extends AsyncOrSync<any, any>[]> = (
 type PipeAsyncSideEffectFrom<Fns extends [FromFn<any>, ...AsyncOrSync<any, any>[]]> = (
   input?: PipeInput<Fns> | SideEffect<any>
 ) => Promise<PipeOutput<Fns>>;
+
+type PipeCheckWithInput<Input, Fns extends [AnyFn, ...AnyFn[]]> =
+  Fns extends [infer F, ...infer Rest]
+    ? F extends AsyncOrSync<any, any>
+      ? Rest extends AnyFn[]
+        ? PipeCheck<[ValidateFn<F, Input>, ...Rest]>
+        : PipeCheck<[ValidateFn<F, Input>]>
+      : PipeError<Input, unknown>
+    : PipeError<unknown, unknown>;
+
+function pipeAsyncSideEffect<A>(input: NonFunction<A> | SideEffect<any>): Promise<A | SideEffect<any>>;
+function pipeAsyncSideEffect<A, F1 extends AsyncOrSync<A, any>>(
+  input: NonFunction<A> | SideEffect<any>,
+  ab: ValidateFn<F1, A>
+): Promise<PipeResult<F1>>;
+function pipeAsyncSideEffect<A, F1 extends AsyncOrSync<A, any>, F2 extends AsyncOrSync<FnValue<F1>, any>>(
+  input: NonFunction<A> | SideEffect<any>,
+  ab: ValidateFn<F1, A>,
+  bc: ValidateFn<F2, FnValue<F1>>
+): Promise<PipeResult<F2>>;
+function pipeAsyncSideEffect<
+  A,
+  F1 extends AsyncOrSync<A, any>,
+  F2 extends AsyncOrSync<FnValue<F1>, any>,
+  F3 extends AsyncOrSync<FnValue<F2>, any>
+>(
+  input: NonFunction<A> | SideEffect<any>,
+  ab: ValidateFn<F1, A>,
+  bc: ValidateFn<F2, FnValue<F1>>,
+  cd: ValidateFn<F3, FnValue<F2>>
+): Promise<PipeResult<F3>>;
+function pipeAsyncSideEffect<
+  A,
+  F1 extends AsyncOrSync<A, any>,
+  F2 extends AsyncOrSync<FnValue<F1>, any>,
+  F3 extends AsyncOrSync<FnValue<F2>, any>,
+  F4 extends AsyncOrSync<FnValue<F3>, any>
+>(
+  input: NonFunction<A> | SideEffect<any>,
+  ab: ValidateFn<F1, A>,
+  bc: ValidateFn<F2, FnValue<F1>>,
+  cd: ValidateFn<F3, FnValue<F2>>,
+  de: ValidateFn<F4, FnValue<F3>>
+): Promise<PipeResult<F4>>;
+function pipeAsyncSideEffect<
+  A,
+  F1 extends AsyncOrSync<A, any>,
+  F2 extends AsyncOrSync<FnValue<F1>, any>,
+  F3 extends AsyncOrSync<FnValue<F2>, any>,
+  F4 extends AsyncOrSync<FnValue<F3>, any>,
+  F5 extends AsyncOrSync<FnValue<F4>, any>
+>(
+  input: NonFunction<A> | SideEffect<any>,
+  ab: ValidateFn<F1, A>,
+  bc: ValidateFn<F2, FnValue<F1>>,
+  cd: ValidateFn<F3, FnValue<F2>>,
+  de: ValidateFn<F4, FnValue<F3>>,
+  ef: ValidateFn<F5, FnValue<F4>>
+): Promise<PipeResult<F5>>;
+function pipeAsyncSideEffect<
+  A,
+  F1 extends AsyncOrSync<A, any>,
+  F2 extends AsyncOrSync<FnValue<F1>, any>,
+  F3 extends AsyncOrSync<FnValue<F2>, any>,
+  F4 extends AsyncOrSync<FnValue<F3>, any>,
+  F5 extends AsyncOrSync<FnValue<F4>, any>,
+  F6 extends AsyncOrSync<FnValue<F5>, any>
+>(
+  input: NonFunction<A> | SideEffect<any>,
+  ab: ValidateFn<F1, A>,
+  bc: ValidateFn<F2, FnValue<F1>>,
+  cd: ValidateFn<F3, FnValue<F2>>,
+  de: ValidateFn<F4, FnValue<F3>>,
+  ef: ValidateFn<F5, FnValue<F4>>,
+  fg: ValidateFn<F6, FnValue<F5>>
+): Promise<PipeResult<F6>>;
+function pipeAsyncSideEffect<
+  A,
+  F1 extends AsyncOrSync<A, any>,
+  F2 extends AsyncOrSync<FnValue<F1>, any>,
+  F3 extends AsyncOrSync<FnValue<F2>, any>,
+  F4 extends AsyncOrSync<FnValue<F3>, any>,
+  F5 extends AsyncOrSync<FnValue<F4>, any>,
+  F6 extends AsyncOrSync<FnValue<F5>, any>,
+  F7 extends AsyncOrSync<FnValue<F6>, any>
+>(
+  input: NonFunction<A> | SideEffect<any>,
+  ab: ValidateFn<F1, A>,
+  bc: ValidateFn<F2, FnValue<F1>>,
+  cd: ValidateFn<F3, FnValue<F2>>,
+  de: ValidateFn<F4, FnValue<F3>>,
+  ef: ValidateFn<F5, FnValue<F4>>,
+  fg: ValidateFn<F6, FnValue<F5>>,
+  gh: ValidateFn<F7, FnValue<F6>>
+): Promise<PipeResult<F7>>;
+function pipeAsyncSideEffect<
+  A,
+  F1 extends AsyncOrSync<A, any>,
+  F2 extends AsyncOrSync<FnValue<F1>, any>,
+  F3 extends AsyncOrSync<FnValue<F2>, any>,
+  F4 extends AsyncOrSync<FnValue<F3>, any>,
+  F5 extends AsyncOrSync<FnValue<F4>, any>,
+  F6 extends AsyncOrSync<FnValue<F5>, any>,
+  F7 extends AsyncOrSync<FnValue<F6>, any>,
+  F8 extends AsyncOrSync<FnValue<F7>, any>
+>(
+  input: NonFunction<A> | SideEffect<any>,
+  ab: ValidateFn<F1, A>,
+  bc: ValidateFn<F2, FnValue<F1>>,
+  cd: ValidateFn<F3, FnValue<F2>>,
+  de: ValidateFn<F4, FnValue<F3>>,
+  ef: ValidateFn<F5, FnValue<F4>>,
+  fg: ValidateFn<F6, FnValue<F5>>,
+  gh: ValidateFn<F7, FnValue<F6>>,
+  hi: ValidateFn<F8, FnValue<F7>>
+): Promise<PipeResult<F8>>;
+function pipeAsyncSideEffect<
+  A,
+  F1 extends AsyncOrSync<A, any>,
+  F2 extends AsyncOrSync<FnValue<F1>, any>,
+  F3 extends AsyncOrSync<FnValue<F2>, any>,
+  F4 extends AsyncOrSync<FnValue<F3>, any>,
+  F5 extends AsyncOrSync<FnValue<F4>, any>,
+  F6 extends AsyncOrSync<FnValue<F5>, any>,
+  F7 extends AsyncOrSync<FnValue<F6>, any>,
+  F8 extends AsyncOrSync<FnValue<F7>, any>,
+  F9 extends AsyncOrSync<FnValue<F8>, any>
+>(
+  input: NonFunction<A> | SideEffect<any>,
+  ab: ValidateFn<F1, A>,
+  bc: ValidateFn<F2, FnValue<F1>>,
+  cd: ValidateFn<F3, FnValue<F2>>,
+  de: ValidateFn<F4, FnValue<F3>>,
+  ef: ValidateFn<F5, FnValue<F4>>,
+  fg: ValidateFn<F6, FnValue<F5>>,
+  gh: ValidateFn<F7, FnValue<F6>>,
+  hi: ValidateFn<F8, FnValue<F7>>,
+  ij: ValidateFn<F9, FnValue<F8>>
+): Promise<PipeResult<F9>>;
+function pipeAsyncSideEffect<
+  A,
+  F1 extends AsyncOrSync<A, any>,
+  F2 extends AsyncOrSync<FnValue<F1>, any>,
+  F3 extends AsyncOrSync<FnValue<F2>, any>,
+  F4 extends AsyncOrSync<FnValue<F3>, any>,
+  F5 extends AsyncOrSync<FnValue<F4>, any>,
+  F6 extends AsyncOrSync<FnValue<F5>, any>,
+  F7 extends AsyncOrSync<FnValue<F6>, any>,
+  F8 extends AsyncOrSync<FnValue<F7>, any>,
+  F9 extends AsyncOrSync<FnValue<F8>, any>,
+  F10 extends AsyncOrSync<FnValue<F9>, any>
+>(
+  input: NonFunction<A> | SideEffect<any>,
+  ab: ValidateFn<F1, A>,
+  bc: ValidateFn<F2, FnValue<F1>>,
+  cd: ValidateFn<F3, FnValue<F2>>,
+  de: ValidateFn<F4, FnValue<F3>>,
+  ef: ValidateFn<F5, FnValue<F4>>,
+  fg: ValidateFn<F6, FnValue<F5>>,
+  gh: ValidateFn<F7, FnValue<F6>>,
+  hi: ValidateFn<F8, FnValue<F7>>,
+  ij: ValidateFn<F9, FnValue<F8>>,
+  jk: ValidateFn<F10, FnValue<F9>>
+): Promise<PipeResult<F10>>;
+function pipeAsyncSideEffect<A, Fns extends [AsyncOrSync<any, any>, ...AsyncOrSync<any, any>[]]>(
+  input: NonFunction<A> | SideEffect<any>,
+  ...funcs: PipeCheckWithInput<A, Fns>
+): Promise<PipeOutput<Fns>>;
 
 function pipeAsyncSideEffect<R>(ab: ZeroFn<R>): () => Promise<PipeResult<ZeroFn<R>>>;
 function pipeAsyncSideEffect<B, F2 extends AsyncOrSync<FnValue<ZeroFn<B>>, any>>(
@@ -470,8 +639,8 @@ function pipeAsyncSideEffect<Fns extends [FirstAsyncOrSync<any, any>, ...AsyncOr
   ...funcs: PipeCheck<Fns>
 ): PipeAsyncSideEffect<Fns>;
 function pipeAsyncSideEffect(...funcs: Array<AsyncOrSync<any, any>>): (value: any) => Promise<any>;
-function pipeAsyncSideEffect(...funcs: Array<(arg: any) => any>) {
-  return async (value: any) => {
+function pipeAsyncSideEffect(...args: Array<any>) {
+  const run = async (value: any, funcs: Array<(arg: any) => any>) => {
     let acc = value;
     for (const fn of funcs) {
       if (isSideEffect(acc)) {
@@ -481,6 +650,17 @@ function pipeAsyncSideEffect(...funcs: Array<(arg: any) => any>) {
     }
     return acc;
   };
+
+  if (args.length === 0) {
+    return Promise.resolve(undefined);
+  }
+  const [input, ...rest] = args as [any, ...Array<(arg: any) => any>];
+  if (typeof input === 'function') {
+    const funcs = [input, ...rest];
+    return (value: any) => run(value, funcs);
+  }
+
+  return run(input, rest);
 }
 
 export default pipeAsyncSideEffect;

--- a/src/implement/async/pipeAsyncSideEffectStrict.test.ts
+++ b/src/implement/async/pipeAsyncSideEffectStrict.test.ts
@@ -14,6 +14,16 @@ describe('pipeAsyncSideEffectStrict', () => {
     expect(result).toBe(effect);
   });
 
+  it('supports data-first invocation', async () => {
+    await expect(
+      pipeAsyncSideEffectStrict(
+        2,
+        async (n: number) => n + 1,
+        (n) => n * 2
+      )
+    ).resolves.toBe(6);
+  });
+
   it('returns SideEffect inputs without executing the pipeline', async () => {
     const effect = new SideEffect(() => 'effect');
     const fn = pipeAsyncSideEffectStrict(async (n: number) => n + 1);

--- a/src/implement/async/pipeAsyncSideEffectStrict.ts
+++ b/src/implement/async/pipeAsyncSideEffectStrict.ts
@@ -4,6 +4,7 @@ import SideEffect, { isSideEffect } from '../composition/sideEffect';
 type PipeError<From, To> = { __pipe_async_side_effect_strict_error: ['pipeAsyncSideEffectStrict', From, '->', To] };
 type NoInfer<T> = [T][T extends any ? 0 : never];
 type AnyFn = (...args: any[]) => any;
+type NonFunction<T> = T extends AnyFn ? never : T;
 
 type MaybeSideEffect<T, E> = T | SideEffect<E>;
 type NonSideEffect<T> = Exclude<T, SideEffect<any>>;
@@ -37,6 +38,7 @@ type EffectOfFn<F> = EffectOfReturn<Awaited<FnReturn<F>>>;
 type EffectsOf<Fns extends AnyFn[]> = EffectOfFn<Fns[number]>;
 
 type StrictResult<FLast, Fns extends AnyFn[]> = MaybeSideEffect<FnValue<FLast>, EffectsOf<Fns>>;
+type StrictResultWithInput<FLast, Fns extends AnyFn[], EIn> = MaybeSideEffect<FnValue<FLast>, EffectsOf<Fns> | EIn>;
 type StrictUnaryReturn<A, FLast, Fns extends AnyFn[]> = {
   (input: A): Promise<StrictResult<FLast, Fns>>;
   <EIn>(input: A | SideEffect<EIn>): Promise<MaybeSideEffect<FnValue<FLast>, EffectsOf<Fns> | EIn>>;
@@ -64,6 +66,345 @@ type PipeAsyncSideEffectStrictFrom<Fns extends [FromFn<any>, ...AsyncOrSync<any,
   LastFn<Fns>,
   Fns
 >;
+
+type PipeCheckWithInput<Input, Fns extends [AnyFn, ...AnyFn[]]> =
+  Fns extends [infer F, ...infer Rest]
+    ? F extends AsyncOrSync<any, any>
+      ? Rest extends AnyFn[]
+        ? PipeCheck<[ValidateFn<F, Input>, ...Rest]>
+        : PipeCheck<[ValidateFn<F, Input>]>
+      : PipeError<Input, unknown>
+    : PipeError<unknown, unknown>;
+
+function pipeAsyncSideEffectStrict<A>(input: NonFunction<A>): Promise<A>;
+function pipeAsyncSideEffectStrict<A, EIn>(input: NonFunction<A> | SideEffect<EIn>): Promise<A | SideEffect<EIn>>;
+function pipeAsyncSideEffectStrict<A, F1 extends AsyncOrSync<A, any>>(
+  input: NonFunction<A>,
+  ab: ValidateFn<F1, A>
+): Promise<StrictResult<F1, [F1]>>;
+function pipeAsyncSideEffectStrict<A, EIn, F1 extends AsyncOrSync<A, any>>(
+  input: NonFunction<A> | SideEffect<EIn>,
+  ab: ValidateFn<F1, A>
+): Promise<StrictResultWithInput<F1, [F1], EIn>>;
+function pipeAsyncSideEffectStrict<A, F1 extends AsyncOrSync<A, any>, F2 extends AsyncOrSync<FnValue<F1>, any>>(
+  input: NonFunction<A>,
+  ab: ValidateFn<F1, A>,
+  bc: ValidateFn<F2, FnValue<F1>>
+): Promise<StrictResult<F2, [F1, F2]>>;
+function pipeAsyncSideEffectStrict<
+  A,
+  EIn,
+  F1 extends AsyncOrSync<A, any>,
+  F2 extends AsyncOrSync<FnValue<F1>, any>
+>(
+  input: NonFunction<A> | SideEffect<EIn>,
+  ab: ValidateFn<F1, A>,
+  bc: ValidateFn<F2, FnValue<F1>>
+): Promise<StrictResultWithInput<F2, [F1, F2], EIn>>;
+function pipeAsyncSideEffectStrict<
+  A,
+  F1 extends AsyncOrSync<A, any>,
+  F2 extends AsyncOrSync<FnValue<F1>, any>,
+  F3 extends AsyncOrSync<FnValue<F2>, any>
+>(
+  input: NonFunction<A>,
+  ab: ValidateFn<F1, A>,
+  bc: ValidateFn<F2, FnValue<F1>>,
+  cd: ValidateFn<F3, FnValue<F2>>
+): Promise<StrictResult<F3, [F1, F2, F3]>>;
+function pipeAsyncSideEffectStrict<
+  A,
+  EIn,
+  F1 extends AsyncOrSync<A, any>,
+  F2 extends AsyncOrSync<FnValue<F1>, any>,
+  F3 extends AsyncOrSync<FnValue<F2>, any>
+>(
+  input: NonFunction<A> | SideEffect<EIn>,
+  ab: ValidateFn<F1, A>,
+  bc: ValidateFn<F2, FnValue<F1>>,
+  cd: ValidateFn<F3, FnValue<F2>>
+): Promise<StrictResultWithInput<F3, [F1, F2, F3], EIn>>;
+function pipeAsyncSideEffectStrict<
+  A,
+  F1 extends AsyncOrSync<A, any>,
+  F2 extends AsyncOrSync<FnValue<F1>, any>,
+  F3 extends AsyncOrSync<FnValue<F2>, any>,
+  F4 extends AsyncOrSync<FnValue<F3>, any>
+>(
+  input: NonFunction<A>,
+  ab: ValidateFn<F1, A>,
+  bc: ValidateFn<F2, FnValue<F1>>,
+  cd: ValidateFn<F3, FnValue<F2>>,
+  de: ValidateFn<F4, FnValue<F3>>
+): Promise<StrictResult<F4, [F1, F2, F3, F4]>>;
+function pipeAsyncSideEffectStrict<
+  A,
+  EIn,
+  F1 extends AsyncOrSync<A, any>,
+  F2 extends AsyncOrSync<FnValue<F1>, any>,
+  F3 extends AsyncOrSync<FnValue<F2>, any>,
+  F4 extends AsyncOrSync<FnValue<F3>, any>
+>(
+  input: NonFunction<A> | SideEffect<EIn>,
+  ab: ValidateFn<F1, A>,
+  bc: ValidateFn<F2, FnValue<F1>>,
+  cd: ValidateFn<F3, FnValue<F2>>,
+  de: ValidateFn<F4, FnValue<F3>>
+): Promise<StrictResultWithInput<F4, [F1, F2, F3, F4], EIn>>;
+function pipeAsyncSideEffectStrict<
+  A,
+  F1 extends AsyncOrSync<A, any>,
+  F2 extends AsyncOrSync<FnValue<F1>, any>,
+  F3 extends AsyncOrSync<FnValue<F2>, any>,
+  F4 extends AsyncOrSync<FnValue<F3>, any>,
+  F5 extends AsyncOrSync<FnValue<F4>, any>
+>(
+  input: NonFunction<A>,
+  ab: ValidateFn<F1, A>,
+  bc: ValidateFn<F2, FnValue<F1>>,
+  cd: ValidateFn<F3, FnValue<F2>>,
+  de: ValidateFn<F4, FnValue<F3>>,
+  ef: ValidateFn<F5, FnValue<F4>>
+): Promise<StrictResult<F5, [F1, F2, F3, F4, F5]>>;
+function pipeAsyncSideEffectStrict<
+  A,
+  EIn,
+  F1 extends AsyncOrSync<A, any>,
+  F2 extends AsyncOrSync<FnValue<F1>, any>,
+  F3 extends AsyncOrSync<FnValue<F2>, any>,
+  F4 extends AsyncOrSync<FnValue<F3>, any>,
+  F5 extends AsyncOrSync<FnValue<F4>, any>
+>(
+  input: NonFunction<A> | SideEffect<EIn>,
+  ab: ValidateFn<F1, A>,
+  bc: ValidateFn<F2, FnValue<F1>>,
+  cd: ValidateFn<F3, FnValue<F2>>,
+  de: ValidateFn<F4, FnValue<F3>>,
+  ef: ValidateFn<F5, FnValue<F4>>
+): Promise<StrictResultWithInput<F5, [F1, F2, F3, F4, F5], EIn>>;
+function pipeAsyncSideEffectStrict<
+  A,
+  F1 extends AsyncOrSync<A, any>,
+  F2 extends AsyncOrSync<FnValue<F1>, any>,
+  F3 extends AsyncOrSync<FnValue<F2>, any>,
+  F4 extends AsyncOrSync<FnValue<F3>, any>,
+  F5 extends AsyncOrSync<FnValue<F4>, any>,
+  F6 extends AsyncOrSync<FnValue<F5>, any>
+>(
+  input: NonFunction<A>,
+  ab: ValidateFn<F1, A>,
+  bc: ValidateFn<F2, FnValue<F1>>,
+  cd: ValidateFn<F3, FnValue<F2>>,
+  de: ValidateFn<F4, FnValue<F3>>,
+  ef: ValidateFn<F5, FnValue<F4>>,
+  fg: ValidateFn<F6, FnValue<F5>>
+): Promise<StrictResult<F6, [F1, F2, F3, F4, F5, F6]>>;
+function pipeAsyncSideEffectStrict<
+  A,
+  EIn,
+  F1 extends AsyncOrSync<A, any>,
+  F2 extends AsyncOrSync<FnValue<F1>, any>,
+  F3 extends AsyncOrSync<FnValue<F2>, any>,
+  F4 extends AsyncOrSync<FnValue<F3>, any>,
+  F5 extends AsyncOrSync<FnValue<F4>, any>,
+  F6 extends AsyncOrSync<FnValue<F5>, any>
+>(
+  input: NonFunction<A> | SideEffect<EIn>,
+  ab: ValidateFn<F1, A>,
+  bc: ValidateFn<F2, FnValue<F1>>,
+  cd: ValidateFn<F3, FnValue<F2>>,
+  de: ValidateFn<F4, FnValue<F3>>,
+  ef: ValidateFn<F5, FnValue<F4>>,
+  fg: ValidateFn<F6, FnValue<F5>>
+): Promise<StrictResultWithInput<F6, [F1, F2, F3, F4, F5, F6], EIn>>;
+function pipeAsyncSideEffectStrict<
+  A,
+  F1 extends AsyncOrSync<A, any>,
+  F2 extends AsyncOrSync<FnValue<F1>, any>,
+  F3 extends AsyncOrSync<FnValue<F2>, any>,
+  F4 extends AsyncOrSync<FnValue<F3>, any>,
+  F5 extends AsyncOrSync<FnValue<F4>, any>,
+  F6 extends AsyncOrSync<FnValue<F5>, any>,
+  F7 extends AsyncOrSync<FnValue<F6>, any>
+>(
+  input: NonFunction<A>,
+  ab: ValidateFn<F1, A>,
+  bc: ValidateFn<F2, FnValue<F1>>,
+  cd: ValidateFn<F3, FnValue<F2>>,
+  de: ValidateFn<F4, FnValue<F3>>,
+  ef: ValidateFn<F5, FnValue<F4>>,
+  fg: ValidateFn<F6, FnValue<F5>>,
+  gh: ValidateFn<F7, FnValue<F6>>
+): Promise<StrictResult<F7, [F1, F2, F3, F4, F5, F6, F7]>>;
+function pipeAsyncSideEffectStrict<
+  A,
+  EIn,
+  F1 extends AsyncOrSync<A, any>,
+  F2 extends AsyncOrSync<FnValue<F1>, any>,
+  F3 extends AsyncOrSync<FnValue<F2>, any>,
+  F4 extends AsyncOrSync<FnValue<F3>, any>,
+  F5 extends AsyncOrSync<FnValue<F4>, any>,
+  F6 extends AsyncOrSync<FnValue<F5>, any>,
+  F7 extends AsyncOrSync<FnValue<F6>, any>
+>(
+  input: NonFunction<A> | SideEffect<EIn>,
+  ab: ValidateFn<F1, A>,
+  bc: ValidateFn<F2, FnValue<F1>>,
+  cd: ValidateFn<F3, FnValue<F2>>,
+  de: ValidateFn<F4, FnValue<F3>>,
+  ef: ValidateFn<F5, FnValue<F4>>,
+  fg: ValidateFn<F6, FnValue<F5>>,
+  gh: ValidateFn<F7, FnValue<F6>>
+): Promise<StrictResultWithInput<F7, [F1, F2, F3, F4, F5, F6, F7], EIn>>;
+function pipeAsyncSideEffectStrict<
+  A,
+  F1 extends AsyncOrSync<A, any>,
+  F2 extends AsyncOrSync<FnValue<F1>, any>,
+  F3 extends AsyncOrSync<FnValue<F2>, any>,
+  F4 extends AsyncOrSync<FnValue<F3>, any>,
+  F5 extends AsyncOrSync<FnValue<F4>, any>,
+  F6 extends AsyncOrSync<FnValue<F5>, any>,
+  F7 extends AsyncOrSync<FnValue<F6>, any>,
+  F8 extends AsyncOrSync<FnValue<F7>, any>
+>(
+  input: NonFunction<A>,
+  ab: ValidateFn<F1, A>,
+  bc: ValidateFn<F2, FnValue<F1>>,
+  cd: ValidateFn<F3, FnValue<F2>>,
+  de: ValidateFn<F4, FnValue<F3>>,
+  ef: ValidateFn<F5, FnValue<F4>>,
+  fg: ValidateFn<F6, FnValue<F5>>,
+  gh: ValidateFn<F7, FnValue<F6>>,
+  hi: ValidateFn<F8, FnValue<F7>>
+): Promise<StrictResult<F8, [F1, F2, F3, F4, F5, F6, F7, F8]>>;
+function pipeAsyncSideEffectStrict<
+  A,
+  EIn,
+  F1 extends AsyncOrSync<A, any>,
+  F2 extends AsyncOrSync<FnValue<F1>, any>,
+  F3 extends AsyncOrSync<FnValue<F2>, any>,
+  F4 extends AsyncOrSync<FnValue<F3>, any>,
+  F5 extends AsyncOrSync<FnValue<F4>, any>,
+  F6 extends AsyncOrSync<FnValue<F5>, any>,
+  F7 extends AsyncOrSync<FnValue<F6>, any>,
+  F8 extends AsyncOrSync<FnValue<F7>, any>
+>(
+  input: NonFunction<A> | SideEffect<EIn>,
+  ab: ValidateFn<F1, A>,
+  bc: ValidateFn<F2, FnValue<F1>>,
+  cd: ValidateFn<F3, FnValue<F2>>,
+  de: ValidateFn<F4, FnValue<F3>>,
+  ef: ValidateFn<F5, FnValue<F4>>,
+  fg: ValidateFn<F6, FnValue<F5>>,
+  gh: ValidateFn<F7, FnValue<F6>>,
+  hi: ValidateFn<F8, FnValue<F7>>
+): Promise<StrictResultWithInput<F8, [F1, F2, F3, F4, F5, F6, F7, F8], EIn>>;
+function pipeAsyncSideEffectStrict<
+  A,
+  F1 extends AsyncOrSync<A, any>,
+  F2 extends AsyncOrSync<FnValue<F1>, any>,
+  F3 extends AsyncOrSync<FnValue<F2>, any>,
+  F4 extends AsyncOrSync<FnValue<F3>, any>,
+  F5 extends AsyncOrSync<FnValue<F4>, any>,
+  F6 extends AsyncOrSync<FnValue<F5>, any>,
+  F7 extends AsyncOrSync<FnValue<F6>, any>,
+  F8 extends AsyncOrSync<FnValue<F7>, any>,
+  F9 extends AsyncOrSync<FnValue<F8>, any>
+>(
+  input: NonFunction<A>,
+  ab: ValidateFn<F1, A>,
+  bc: ValidateFn<F2, FnValue<F1>>,
+  cd: ValidateFn<F3, FnValue<F2>>,
+  de: ValidateFn<F4, FnValue<F3>>,
+  ef: ValidateFn<F5, FnValue<F4>>,
+  fg: ValidateFn<F6, FnValue<F5>>,
+  gh: ValidateFn<F7, FnValue<F6>>,
+  hi: ValidateFn<F8, FnValue<F7>>,
+  ij: ValidateFn<F9, FnValue<F8>>
+): Promise<StrictResult<F9, [F1, F2, F3, F4, F5, F6, F7, F8, F9]>>;
+function pipeAsyncSideEffectStrict<
+  A,
+  EIn,
+  F1 extends AsyncOrSync<A, any>,
+  F2 extends AsyncOrSync<FnValue<F1>, any>,
+  F3 extends AsyncOrSync<FnValue<F2>, any>,
+  F4 extends AsyncOrSync<FnValue<F3>, any>,
+  F5 extends AsyncOrSync<FnValue<F4>, any>,
+  F6 extends AsyncOrSync<FnValue<F5>, any>,
+  F7 extends AsyncOrSync<FnValue<F6>, any>,
+  F8 extends AsyncOrSync<FnValue<F7>, any>,
+  F9 extends AsyncOrSync<FnValue<F8>, any>
+>(
+  input: NonFunction<A> | SideEffect<EIn>,
+  ab: ValidateFn<F1, A>,
+  bc: ValidateFn<F2, FnValue<F1>>,
+  cd: ValidateFn<F3, FnValue<F2>>,
+  de: ValidateFn<F4, FnValue<F3>>,
+  ef: ValidateFn<F5, FnValue<F4>>,
+  fg: ValidateFn<F6, FnValue<F5>>,
+  gh: ValidateFn<F7, FnValue<F6>>,
+  hi: ValidateFn<F8, FnValue<F7>>,
+  ij: ValidateFn<F9, FnValue<F8>>
+): Promise<StrictResultWithInput<F9, [F1, F2, F3, F4, F5, F6, F7, F8, F9], EIn>>;
+function pipeAsyncSideEffectStrict<
+  A,
+  F1 extends AsyncOrSync<A, any>,
+  F2 extends AsyncOrSync<FnValue<F1>, any>,
+  F3 extends AsyncOrSync<FnValue<F2>, any>,
+  F4 extends AsyncOrSync<FnValue<F3>, any>,
+  F5 extends AsyncOrSync<FnValue<F4>, any>,
+  F6 extends AsyncOrSync<FnValue<F5>, any>,
+  F7 extends AsyncOrSync<FnValue<F6>, any>,
+  F8 extends AsyncOrSync<FnValue<F7>, any>,
+  F9 extends AsyncOrSync<FnValue<F8>, any>,
+  F10 extends AsyncOrSync<FnValue<F9>, any>
+>(
+  input: NonFunction<A>,
+  ab: ValidateFn<F1, A>,
+  bc: ValidateFn<F2, FnValue<F1>>,
+  cd: ValidateFn<F3, FnValue<F2>>,
+  de: ValidateFn<F4, FnValue<F3>>,
+  ef: ValidateFn<F5, FnValue<F4>>,
+  fg: ValidateFn<F6, FnValue<F5>>,
+  gh: ValidateFn<F7, FnValue<F6>>,
+  hi: ValidateFn<F8, FnValue<F7>>,
+  ij: ValidateFn<F9, FnValue<F8>>,
+  jk: ValidateFn<F10, FnValue<F9>>
+): Promise<StrictResult<F10, [F1, F2, F3, F4, F5, F6, F7, F8, F9, F10]>>;
+function pipeAsyncSideEffectStrict<
+  A,
+  EIn,
+  F1 extends AsyncOrSync<A, any>,
+  F2 extends AsyncOrSync<FnValue<F1>, any>,
+  F3 extends AsyncOrSync<FnValue<F2>, any>,
+  F4 extends AsyncOrSync<FnValue<F3>, any>,
+  F5 extends AsyncOrSync<FnValue<F4>, any>,
+  F6 extends AsyncOrSync<FnValue<F5>, any>,
+  F7 extends AsyncOrSync<FnValue<F6>, any>,
+  F8 extends AsyncOrSync<FnValue<F7>, any>,
+  F9 extends AsyncOrSync<FnValue<F8>, any>,
+  F10 extends AsyncOrSync<FnValue<F9>, any>
+>(
+  input: NonFunction<A> | SideEffect<EIn>,
+  ab: ValidateFn<F1, A>,
+  bc: ValidateFn<F2, FnValue<F1>>,
+  cd: ValidateFn<F3, FnValue<F2>>,
+  de: ValidateFn<F4, FnValue<F3>>,
+  ef: ValidateFn<F5, FnValue<F4>>,
+  fg: ValidateFn<F6, FnValue<F5>>,
+  gh: ValidateFn<F7, FnValue<F6>>,
+  hi: ValidateFn<F8, FnValue<F7>>,
+  ij: ValidateFn<F9, FnValue<F8>>,
+  jk: ValidateFn<F10, FnValue<F9>>
+): Promise<StrictResultWithInput<F10, [F1, F2, F3, F4, F5, F6, F7, F8, F9, F10], EIn>>;
+function pipeAsyncSideEffectStrict<A, Fns extends [AsyncOrSync<any, any>, ...AsyncOrSync<any, any>[]]>(
+  input: NonFunction<A>,
+  ...funcs: PipeCheckWithInput<A, Fns>
+): Promise<StrictResult<LastFn<Fns>, Fns>>;
+function pipeAsyncSideEffectStrict<A, EIn, Fns extends [AsyncOrSync<any, any>, ...AsyncOrSync<any, any>[]]>(
+  input: NonFunction<A> | SideEffect<EIn>,
+  ...funcs: PipeCheckWithInput<A, Fns>
+): Promise<StrictResultWithInput<LastFn<Fns>, Fns, EIn>>;
 
 function pipeAsyncSideEffectStrict<R>(ab: ZeroFn<R>): () => Promise<StrictResult<ZeroFn<R>, [ZeroFn<R>]>>;
 function pipeAsyncSideEffectStrict<B, F2 extends AsyncOrSync<FnValue<ZeroFn<B>>, any>>(
@@ -480,8 +821,8 @@ function pipeAsyncSideEffectStrict<Fns extends [FromFn<any>, ...AsyncOrSync<any,
 function pipeAsyncSideEffectStrict<Fns extends [FirstAsyncOrSync<any, any>, ...AsyncOrSync<any, any>[]]>(
   ...funcs: PipeCheck<Fns>
 ): PipeAsyncSideEffectStrict<Fns>;
-function pipeAsyncSideEffectStrict(...funcs: Array<(input: any) => any>) {
-  return async (init?: any) => {
+function pipeAsyncSideEffectStrict(...args: Array<any>) {
+  const run = async (init: any, funcs: Array<(input: any) => any>) => {
     let acc = init;
     for (const fn of funcs) {
       if (isSideEffect(acc)) {
@@ -491,6 +832,17 @@ function pipeAsyncSideEffectStrict(...funcs: Array<(input: any) => any>) {
     }
     return acc;
   };
+
+  if (args.length === 0) {
+    return Promise.resolve(undefined);
+  }
+  const [input, ...rest] = args as [any, ...Array<(input: any) => any>];
+  if (typeof input === 'function') {
+    const funcs = [input, ...rest];
+    return (init?: any) => run(init, funcs);
+  }
+
+  return run(input, rest);
 }
 
 export default pipeAsyncSideEffectStrict;

--- a/src/implement/composition/pipe.test.ts
+++ b/src/implement/composition/pipe.test.ts
@@ -11,6 +11,13 @@ describe('pipe', () => {
     expect(fn(3)).toBe('8'); // (3 + 1) * 2 => 8
   });
 
+  it('supports data-first invocation', () => {
+    const addOne = (n: number) => n + 1;
+    const double = (n: number) => n * 2;
+
+    expect(pipe(3, addOne, double)).toBe(8);
+  });
+
   it('supports mixed types through the chain', () => {
     const trim = (s: string) => s.trim();
     const splitComma = (s: string) => s.split(',');

--- a/src/implement/composition/pipe.ts
+++ b/src/implement/composition/pipe.ts
@@ -5,6 +5,7 @@ type NoInfer<T> = [T][T extends any ? 0 : never];
 type UnaryFn<A, R> = (a: A) => R;
 type ZeroFn<R> = () => R;
 type AnyFn = (...args: any[]) => any;
+type NonFunction<T> = T extends AnyFn ? never : T;
 type FnInput<F> = F extends (a: infer A) => any ? A : never;
 type FnOutput<F> = F extends (...args: any[]) => infer R ? R : never;
 type ValidateFn<Fn extends UnaryFn<any, any>, Expected> =
@@ -35,6 +36,171 @@ type PipeOutput<Fns extends UnaryFn<any, any>[]> = Fns extends [UnaryFn<any, inf
       : never
     : never;
 type Pipe<Fns extends UnaryFn<any, any>[]> = (input: PipeInput<Fns>) => PipeOutput<Fns>;
+
+type PipeCheckWithInput<Input, Fns extends [AnyFn, ...AnyFn[]]> =
+  Fns extends [infer F, ...infer Rest]
+    ? F extends UnaryFn<any, any>
+      ? Rest extends AnyFn[]
+        ? PipeCheck<[ValidateFn<F, Input>, ...Rest]>
+        : PipeCheck<[ValidateFn<F, Input>]>
+      : PipeError<Input, unknown>
+    : PipeError<unknown, unknown>;
+
+function pipe<A>(input: NonFunction<A>): A;
+function pipe<A, F1 extends UnaryFn<A, any>>(input: NonFunction<A>, ab: ValidateFn<F1, A>): FnOutput<F1>;
+function pipe<A, F1 extends UnaryFn<A, any>, F2 extends UnaryFn<FnOutput<F1>, any>>(
+  input: NonFunction<A>,
+  ab: ValidateFn<F1, A>,
+  bc: ValidateFn<F2, FnOutput<F1>>
+): FnOutput<F2>;
+function pipe<
+  A,
+  F1 extends UnaryFn<A, any>,
+  F2 extends UnaryFn<FnOutput<F1>, any>,
+  F3 extends UnaryFn<FnOutput<F2>, any>
+>(
+  input: NonFunction<A>,
+  ab: ValidateFn<F1, A>,
+  bc: ValidateFn<F2, FnOutput<F1>>,
+  cd: ValidateFn<F3, FnOutput<F2>>
+): FnOutput<F3>;
+function pipe<
+  A,
+  F1 extends UnaryFn<A, any>,
+  F2 extends UnaryFn<FnOutput<F1>, any>,
+  F3 extends UnaryFn<FnOutput<F2>, any>,
+  F4 extends UnaryFn<FnOutput<F3>, any>
+>(
+  input: NonFunction<A>,
+  ab: ValidateFn<F1, A>,
+  bc: ValidateFn<F2, FnOutput<F1>>,
+  cd: ValidateFn<F3, FnOutput<F2>>,
+  de: ValidateFn<F4, FnOutput<F3>>
+): FnOutput<F4>;
+function pipe<
+  A,
+  F1 extends UnaryFn<A, any>,
+  F2 extends UnaryFn<FnOutput<F1>, any>,
+  F3 extends UnaryFn<FnOutput<F2>, any>,
+  F4 extends UnaryFn<FnOutput<F3>, any>,
+  F5 extends UnaryFn<FnOutput<F4>, any>
+>(
+  input: NonFunction<A>,
+  ab: ValidateFn<F1, A>,
+  bc: ValidateFn<F2, FnOutput<F1>>,
+  cd: ValidateFn<F3, FnOutput<F2>>,
+  de: ValidateFn<F4, FnOutput<F3>>,
+  ef: ValidateFn<F5, FnOutput<F4>>
+): FnOutput<F5>;
+function pipe<
+  A,
+  F1 extends UnaryFn<A, any>,
+  F2 extends UnaryFn<FnOutput<F1>, any>,
+  F3 extends UnaryFn<FnOutput<F2>, any>,
+  F4 extends UnaryFn<FnOutput<F3>, any>,
+  F5 extends UnaryFn<FnOutput<F4>, any>,
+  F6 extends UnaryFn<FnOutput<F5>, any>
+>(
+  input: NonFunction<A>,
+  ab: ValidateFn<F1, A>,
+  bc: ValidateFn<F2, FnOutput<F1>>,
+  cd: ValidateFn<F3, FnOutput<F2>>,
+  de: ValidateFn<F4, FnOutput<F3>>,
+  ef: ValidateFn<F5, FnOutput<F4>>,
+  fg: ValidateFn<F6, FnOutput<F5>>
+): FnOutput<F6>;
+function pipe<
+  A,
+  F1 extends UnaryFn<A, any>,
+  F2 extends UnaryFn<FnOutput<F1>, any>,
+  F3 extends UnaryFn<FnOutput<F2>, any>,
+  F4 extends UnaryFn<FnOutput<F3>, any>,
+  F5 extends UnaryFn<FnOutput<F4>, any>,
+  F6 extends UnaryFn<FnOutput<F5>, any>,
+  F7 extends UnaryFn<FnOutput<F6>, any>
+>(
+  input: NonFunction<A>,
+  ab: ValidateFn<F1, A>,
+  bc: ValidateFn<F2, FnOutput<F1>>,
+  cd: ValidateFn<F3, FnOutput<F2>>,
+  de: ValidateFn<F4, FnOutput<F3>>,
+  ef: ValidateFn<F5, FnOutput<F4>>,
+  fg: ValidateFn<F6, FnOutput<F5>>,
+  gh: ValidateFn<F7, FnOutput<F6>>
+): FnOutput<F7>;
+function pipe<
+  A,
+  F1 extends UnaryFn<A, any>,
+  F2 extends UnaryFn<FnOutput<F1>, any>,
+  F3 extends UnaryFn<FnOutput<F2>, any>,
+  F4 extends UnaryFn<FnOutput<F3>, any>,
+  F5 extends UnaryFn<FnOutput<F4>, any>,
+  F6 extends UnaryFn<FnOutput<F5>, any>,
+  F7 extends UnaryFn<FnOutput<F6>, any>,
+  F8 extends UnaryFn<FnOutput<F7>, any>
+>(
+  input: NonFunction<A>,
+  ab: ValidateFn<F1, A>,
+  bc: ValidateFn<F2, FnOutput<F1>>,
+  cd: ValidateFn<F3, FnOutput<F2>>,
+  de: ValidateFn<F4, FnOutput<F3>>,
+  ef: ValidateFn<F5, FnOutput<F4>>,
+  fg: ValidateFn<F6, FnOutput<F5>>,
+  gh: ValidateFn<F7, FnOutput<F6>>,
+  hi: ValidateFn<F8, FnOutput<F7>>
+): FnOutput<F8>;
+function pipe<
+  A,
+  F1 extends UnaryFn<A, any>,
+  F2 extends UnaryFn<FnOutput<F1>, any>,
+  F3 extends UnaryFn<FnOutput<F2>, any>,
+  F4 extends UnaryFn<FnOutput<F3>, any>,
+  F5 extends UnaryFn<FnOutput<F4>, any>,
+  F6 extends UnaryFn<FnOutput<F5>, any>,
+  F7 extends UnaryFn<FnOutput<F6>, any>,
+  F8 extends UnaryFn<FnOutput<F7>, any>,
+  F9 extends UnaryFn<FnOutput<F8>, any>
+>(
+  input: NonFunction<A>,
+  ab: ValidateFn<F1, A>,
+  bc: ValidateFn<F2, FnOutput<F1>>,
+  cd: ValidateFn<F3, FnOutput<F2>>,
+  de: ValidateFn<F4, FnOutput<F3>>,
+  ef: ValidateFn<F5, FnOutput<F4>>,
+  fg: ValidateFn<F6, FnOutput<F5>>,
+  gh: ValidateFn<F7, FnOutput<F6>>,
+  hi: ValidateFn<F8, FnOutput<F7>>,
+  ij: ValidateFn<F9, FnOutput<F8>>
+): FnOutput<F9>;
+function pipe<
+  A,
+  F1 extends UnaryFn<A, any>,
+  F2 extends UnaryFn<FnOutput<F1>, any>,
+  F3 extends UnaryFn<FnOutput<F2>, any>,
+  F4 extends UnaryFn<FnOutput<F3>, any>,
+  F5 extends UnaryFn<FnOutput<F4>, any>,
+  F6 extends UnaryFn<FnOutput<F5>, any>,
+  F7 extends UnaryFn<FnOutput<F6>, any>,
+  F8 extends UnaryFn<FnOutput<F7>, any>,
+  F9 extends UnaryFn<FnOutput<F8>, any>,
+  F10 extends UnaryFn<FnOutput<F9>, any>
+>(
+  input: NonFunction<A>,
+  ab: ValidateFn<F1, A>,
+  bc: ValidateFn<F2, FnOutput<F1>>,
+  cd: ValidateFn<F3, FnOutput<F2>>,
+  de: ValidateFn<F4, FnOutput<F3>>,
+  ef: ValidateFn<F5, FnOutput<F4>>,
+  fg: ValidateFn<F6, FnOutput<F5>>,
+  gh: ValidateFn<F7, FnOutput<F6>>,
+  hi: ValidateFn<F8, FnOutput<F7>>,
+  ij: ValidateFn<F9, FnOutput<F8>>,
+  jk: ValidateFn<F10, FnOutput<F9>>
+): FnOutput<F10>;
+function pipe<A, Fns extends [UnaryFn<any, any>, ...UnaryFn<any, any>[]]>(
+  input: NonFunction<A>,
+  ...funcs: PipeCheckWithInput<A, Fns>
+): PipeOutput<Fns>;
 
 function pipe<R>(ab: ZeroFn<R>): () => R;
 function pipe<B, F2 extends UnaryFn<B, any>>(ab: ZeroFn<B>, bc: ValidateFn<F2, B>): () => FnOutput<F2>;
@@ -433,10 +599,16 @@ function pipe<
 
 function pipe<Fns extends [UnaryFn<any, any>, ...UnaryFn<any, any>[]]>(...funcs: PipeCheck<Fns>): Pipe<Fns>;
 function pipe(...funcs: Array<UnaryFn<any, any>>): (input: any) => any;
-function pipe(...funcs: Array<(input: any) => any>) {
-  return (init: any) => {
-    return funcs.reduce((acc, fn) => fn(acc), init);
-  };
+function pipe(...args: Array<any>) {
+  if (args.length === 0) {
+    return undefined;
+  }
+  const [input, ...rest] = args as [any, ...Array<(input: any) => any>];
+  if (typeof input === 'function') {
+    const funcs = [input, ...rest];
+    return (init: any) => funcs.reduce((acc, fn) => fn(acc), init);
+  }
+  return rest.reduce((acc, fn) => fn(acc), input);
 }
 
 export default pipe;

--- a/src/implement/composition/pipeSideEffect.test.ts
+++ b/src/implement/composition/pipeSideEffect.test.ts
@@ -14,6 +14,13 @@ describe('pipeSideEffect', () => {
     expect(result).toBe(effect);
   });
 
+  it('supports data-first invocation', () => {
+    const addOne = (n: number) => n + 1;
+    const double = (n: number) => n * 2;
+
+    expect(pipeSideEffect(2, addOne, double)).toBe(6);
+  });
+
   it('returns SideEffect inputs without executing the pipeline', () => {
     const effect = new SideEffect(() => 'effect');
     const fn = pipeSideEffect((n: number) => n + 1);

--- a/src/implement/composition/pipeSideEffect.ts
+++ b/src/implement/composition/pipeSideEffect.ts
@@ -9,6 +9,7 @@ type NonSideEffect<T> = Exclude<T, SideEffect<any>>;
 type UnaryFn<A, R> = (a: A) => MaybeSideEffect<R>;
 type ZeroFn<R> = () => MaybeSideEffect<R>;
 type AnyFn = (...args: any[]) => any;
+type NonFunction<T> = T extends AnyFn ? never : T;
 
 type FnInput<F> = F extends (a: infer A) => any ? A : never;
 type FnReturn<F> = F extends (...args: any[]) => infer R ? R : never;
@@ -52,6 +53,174 @@ type PipeSideEffect<Fns extends UnaryFn<any, any>[]> = (input: PipeInput<Fns> | 
 type PipeSideEffectFrom<Fns extends [FromFn<any>, ...UnaryFn<any, any>[]]> = (
   input?: PipeInput<Fns> | SideEffect<any>
 ) => PipeOutput<Fns>;
+
+type PipeCheckWithInput<Input, Fns extends [AnyFn, ...AnyFn[]]> =
+  Fns extends [infer F, ...infer Rest]
+    ? F extends UnaryFn<any, any>
+      ? Rest extends AnyFn[]
+        ? PipeCheck<[ValidateFn<F, Input>, ...Rest]>
+        : PipeCheck<[ValidateFn<F, Input>]>
+      : PipeError<Input, unknown>
+    : PipeError<unknown, unknown>;
+
+function pipeSideEffect<A>(input: NonFunction<A> | SideEffect<any>): A | SideEffect<any>;
+function pipeSideEffect<A, F1 extends UnaryFn<A, any>>(
+  input: NonFunction<A> | SideEffect<any>,
+  ab: ValidateFn<F1, A>
+): PipeResult<F1>;
+function pipeSideEffect<A, F1 extends UnaryFn<A, any>, F2 extends UnaryFn<FnValue<F1>, any>>(
+  input: NonFunction<A> | SideEffect<any>,
+  ab: ValidateFn<F1, A>,
+  bc: ValidateFn<F2, FnValue<F1>>
+): PipeResult<F2>;
+function pipeSideEffect<
+  A,
+  F1 extends UnaryFn<A, any>,
+  F2 extends UnaryFn<FnValue<F1>, any>,
+  F3 extends UnaryFn<FnValue<F2>, any>
+>(
+  input: NonFunction<A> | SideEffect<any>,
+  ab: ValidateFn<F1, A>,
+  bc: ValidateFn<F2, FnValue<F1>>,
+  cd: ValidateFn<F3, FnValue<F2>>
+): PipeResult<F3>;
+function pipeSideEffect<
+  A,
+  F1 extends UnaryFn<A, any>,
+  F2 extends UnaryFn<FnValue<F1>, any>,
+  F3 extends UnaryFn<FnValue<F2>, any>,
+  F4 extends UnaryFn<FnValue<F3>, any>
+>(
+  input: NonFunction<A> | SideEffect<any>,
+  ab: ValidateFn<F1, A>,
+  bc: ValidateFn<F2, FnValue<F1>>,
+  cd: ValidateFn<F3, FnValue<F2>>,
+  de: ValidateFn<F4, FnValue<F3>>
+): PipeResult<F4>;
+function pipeSideEffect<
+  A,
+  F1 extends UnaryFn<A, any>,
+  F2 extends UnaryFn<FnValue<F1>, any>,
+  F3 extends UnaryFn<FnValue<F2>, any>,
+  F4 extends UnaryFn<FnValue<F3>, any>,
+  F5 extends UnaryFn<FnValue<F4>, any>
+>(
+  input: NonFunction<A> | SideEffect<any>,
+  ab: ValidateFn<F1, A>,
+  bc: ValidateFn<F2, FnValue<F1>>,
+  cd: ValidateFn<F3, FnValue<F2>>,
+  de: ValidateFn<F4, FnValue<F3>>,
+  ef: ValidateFn<F5, FnValue<F4>>
+): PipeResult<F5>;
+function pipeSideEffect<
+  A,
+  F1 extends UnaryFn<A, any>,
+  F2 extends UnaryFn<FnValue<F1>, any>,
+  F3 extends UnaryFn<FnValue<F2>, any>,
+  F4 extends UnaryFn<FnValue<F3>, any>,
+  F5 extends UnaryFn<FnValue<F4>, any>,
+  F6 extends UnaryFn<FnValue<F5>, any>
+>(
+  input: NonFunction<A> | SideEffect<any>,
+  ab: ValidateFn<F1, A>,
+  bc: ValidateFn<F2, FnValue<F1>>,
+  cd: ValidateFn<F3, FnValue<F2>>,
+  de: ValidateFn<F4, FnValue<F3>>,
+  ef: ValidateFn<F5, FnValue<F4>>,
+  fg: ValidateFn<F6, FnValue<F5>>
+): PipeResult<F6>;
+function pipeSideEffect<
+  A,
+  F1 extends UnaryFn<A, any>,
+  F2 extends UnaryFn<FnValue<F1>, any>,
+  F3 extends UnaryFn<FnValue<F2>, any>,
+  F4 extends UnaryFn<FnValue<F3>, any>,
+  F5 extends UnaryFn<FnValue<F4>, any>,
+  F6 extends UnaryFn<FnValue<F5>, any>,
+  F7 extends UnaryFn<FnValue<F6>, any>
+>(
+  input: NonFunction<A> | SideEffect<any>,
+  ab: ValidateFn<F1, A>,
+  bc: ValidateFn<F2, FnValue<F1>>,
+  cd: ValidateFn<F3, FnValue<F2>>,
+  de: ValidateFn<F4, FnValue<F3>>,
+  ef: ValidateFn<F5, FnValue<F4>>,
+  fg: ValidateFn<F6, FnValue<F5>>,
+  gh: ValidateFn<F7, FnValue<F6>>
+): PipeResult<F7>;
+function pipeSideEffect<
+  A,
+  F1 extends UnaryFn<A, any>,
+  F2 extends UnaryFn<FnValue<F1>, any>,
+  F3 extends UnaryFn<FnValue<F2>, any>,
+  F4 extends UnaryFn<FnValue<F3>, any>,
+  F5 extends UnaryFn<FnValue<F4>, any>,
+  F6 extends UnaryFn<FnValue<F5>, any>,
+  F7 extends UnaryFn<FnValue<F6>, any>,
+  F8 extends UnaryFn<FnValue<F7>, any>
+>(
+  input: NonFunction<A> | SideEffect<any>,
+  ab: ValidateFn<F1, A>,
+  bc: ValidateFn<F2, FnValue<F1>>,
+  cd: ValidateFn<F3, FnValue<F2>>,
+  de: ValidateFn<F4, FnValue<F3>>,
+  ef: ValidateFn<F5, FnValue<F4>>,
+  fg: ValidateFn<F6, FnValue<F5>>,
+  gh: ValidateFn<F7, FnValue<F6>>,
+  hi: ValidateFn<F8, FnValue<F7>>
+): PipeResult<F8>;
+function pipeSideEffect<
+  A,
+  F1 extends UnaryFn<A, any>,
+  F2 extends UnaryFn<FnValue<F1>, any>,
+  F3 extends UnaryFn<FnValue<F2>, any>,
+  F4 extends UnaryFn<FnValue<F3>, any>,
+  F5 extends UnaryFn<FnValue<F4>, any>,
+  F6 extends UnaryFn<FnValue<F5>, any>,
+  F7 extends UnaryFn<FnValue<F6>, any>,
+  F8 extends UnaryFn<FnValue<F7>, any>,
+  F9 extends UnaryFn<FnValue<F8>, any>
+>(
+  input: NonFunction<A> | SideEffect<any>,
+  ab: ValidateFn<F1, A>,
+  bc: ValidateFn<F2, FnValue<F1>>,
+  cd: ValidateFn<F3, FnValue<F2>>,
+  de: ValidateFn<F4, FnValue<F3>>,
+  ef: ValidateFn<F5, FnValue<F4>>,
+  fg: ValidateFn<F6, FnValue<F5>>,
+  gh: ValidateFn<F7, FnValue<F6>>,
+  hi: ValidateFn<F8, FnValue<F7>>,
+  ij: ValidateFn<F9, FnValue<F8>>
+): PipeResult<F9>;
+function pipeSideEffect<
+  A,
+  F1 extends UnaryFn<A, any>,
+  F2 extends UnaryFn<FnValue<F1>, any>,
+  F3 extends UnaryFn<FnValue<F2>, any>,
+  F4 extends UnaryFn<FnValue<F3>, any>,
+  F5 extends UnaryFn<FnValue<F4>, any>,
+  F6 extends UnaryFn<FnValue<F5>, any>,
+  F7 extends UnaryFn<FnValue<F6>, any>,
+  F8 extends UnaryFn<FnValue<F7>, any>,
+  F9 extends UnaryFn<FnValue<F8>, any>,
+  F10 extends UnaryFn<FnValue<F9>, any>
+>(
+  input: NonFunction<A> | SideEffect<any>,
+  ab: ValidateFn<F1, A>,
+  bc: ValidateFn<F2, FnValue<F1>>,
+  cd: ValidateFn<F3, FnValue<F2>>,
+  de: ValidateFn<F4, FnValue<F3>>,
+  ef: ValidateFn<F5, FnValue<F4>>,
+  fg: ValidateFn<F6, FnValue<F5>>,
+  gh: ValidateFn<F7, FnValue<F6>>,
+  hi: ValidateFn<F8, FnValue<F7>>,
+  ij: ValidateFn<F9, FnValue<F8>>,
+  jk: ValidateFn<F10, FnValue<F9>>
+): PipeResult<F10>;
+function pipeSideEffect<A, Fns extends [UnaryFn<any, any>, ...UnaryFn<any, any>[]]>(
+  input: NonFunction<A> | SideEffect<any>,
+  ...funcs: PipeCheckWithInput<A, Fns>
+): PipeOutput<Fns>;
 
 function pipeSideEffect<R>(ab: ZeroFn<R>): () => PipeResult<ZeroFn<R>>;
 function pipeSideEffect<B, F2 extends UnaryFn<B, any>>(ab: ZeroFn<B>, bc: ValidateFn<F2, B>): () => PipeResult<F2>;
@@ -452,9 +621,9 @@ function pipeSideEffect<
 
 function pipeSideEffect<Fns extends [FromFn<any>, ...UnaryFn<any, any>[]]>(...funcs: PipeCheck<Fns>): PipeSideEffectFrom<Fns>;
 function pipeSideEffect<Fns extends [UnaryFn<any, any>, ...UnaryFn<any, any>[]]>(...funcs: PipeCheck<Fns>): PipeSideEffect<Fns>;
-function pipeSideEffect(...funcs: Array<UnaryFn<any, any>>): (input: any) => any;
-function pipeSideEffect(...funcs: Array<(input: any) => any>) {
-  return (init: any) => {
+function pipeSideEffect(...args: Array<UnaryFn<any, any>>): (input: any) => any;
+function pipeSideEffect(...args: Array<any>) {
+  const run = (init: any, funcs: Array<(input: any) => any>) => {
     let acc = init;
     for (const fn of funcs) {
       if (isSideEffect(acc)) {
@@ -464,6 +633,17 @@ function pipeSideEffect(...funcs: Array<(input: any) => any>) {
     }
     return acc;
   };
+
+  if (args.length === 0) {
+    return undefined;
+  }
+  const [input, ...rest] = args as [any, ...Array<(input: any) => any>];
+  if (typeof input === 'function') {
+    const funcs = [input, ...rest];
+    return (init: any) => run(init, funcs);
+  }
+
+  return run(input, rest);
 }
 
 export default pipeSideEffect;

--- a/src/implement/composition/pipeSideEffectStrict.test.ts
+++ b/src/implement/composition/pipeSideEffectStrict.test.ts
@@ -14,6 +14,13 @@ describe('pipeSideEffectStrict', () => {
     expect(result).toBe(effect);
   });
 
+  it('supports data-first invocation', () => {
+    const addOne = (n: number) => n + 1;
+    const double = (n: number) => n * 2;
+
+    expect(pipeSideEffectStrict(2, addOne, double)).toBe(6);
+  });
+
   it('returns SideEffect inputs without executing the pipeline', () => {
     const effect = new SideEffect(() => 'effect');
     const fn = pipeSideEffectStrict((n: number) => n + 1);

--- a/src/implement/composition/pipeSideEffectStrict.ts
+++ b/src/implement/composition/pipeSideEffectStrict.ts
@@ -4,6 +4,7 @@ import SideEffect, { isSideEffect } from './sideEffect';
 type PipeError<From, To> = { __pipe_side_effect_strict_error: ['pipeSideEffectStrict', From, '->', To] };
 type NoInfer<T> = [T][T extends any ? 0 : never];
 type AnyFn = (...args: any[]) => any;
+type NonFunction<T> = T extends AnyFn ? never : T;
 
 type MaybeSideEffect<T, E> = T | SideEffect<E>;
 type NonSideEffect<T> = Exclude<T, SideEffect<any>>;
@@ -36,6 +37,7 @@ type EffectOfFn<F> = EffectOfReturn<FnReturn<F>>;
 type EffectsOf<Fns extends AnyFn[]> = EffectOfFn<Fns[number]>;
 
 type StrictResult<FLast, Fns extends AnyFn[]> = MaybeSideEffect<FnValue<FLast>, EffectsOf<Fns>>;
+type StrictResultWithInput<FLast, Fns extends AnyFn[], EIn> = MaybeSideEffect<FnValue<FLast>, EffectsOf<Fns> | EIn>;
 type StrictUnaryReturn<A, FLast, Fns extends AnyFn[]> = {
   (input: A): StrictResult<FLast, Fns>;
   <EIn>(input: A | SideEffect<EIn>): MaybeSideEffect<FnValue<FLast>, EffectsOf<Fns> | EIn>;
@@ -60,6 +62,340 @@ type PipeSideEffectStrictFrom<Fns extends [FromFn<any>, ...UnaryFn<any, any>[]]>
   LastFn<Fns>,
   Fns
 >;
+
+type PipeCheckWithInput<Input, Fns extends [AnyFn, ...AnyFn[]]> =
+  Fns extends [infer F, ...infer Rest]
+    ? F extends UnaryFn<any, any>
+      ? Rest extends AnyFn[]
+        ? PipeCheck<[ValidateFn<F, Input>, ...Rest]>
+        : PipeCheck<[ValidateFn<F, Input>]>
+      : PipeError<Input, unknown>
+    : PipeError<unknown, unknown>;
+
+function pipeSideEffectStrict<A>(input: NonFunction<A>): A;
+function pipeSideEffectStrict<A, EIn>(input: NonFunction<A> | SideEffect<EIn>): A | SideEffect<EIn>;
+function pipeSideEffectStrict<A, F1 extends UnaryFn<A, any>>(
+  input: NonFunction<A>,
+  ab: ValidateFn<F1, A>
+): StrictResult<F1, [F1]>;
+function pipeSideEffectStrict<A, EIn, F1 extends UnaryFn<A, any>>(
+  input: NonFunction<A> | SideEffect<EIn>,
+  ab: ValidateFn<F1, A>
+): StrictResultWithInput<F1, [F1], EIn>;
+function pipeSideEffectStrict<A, F1 extends UnaryFn<A, any>, F2 extends UnaryFn<FnValue<F1>, any>>(
+  input: NonFunction<A>,
+  ab: ValidateFn<F1, A>,
+  bc: ValidateFn<F2, FnValue<F1>>
+): StrictResult<F2, [F1, F2]>;
+function pipeSideEffectStrict<A, EIn, F1 extends UnaryFn<A, any>, F2 extends UnaryFn<FnValue<F1>, any>>(
+  input: NonFunction<A> | SideEffect<EIn>,
+  ab: ValidateFn<F1, A>,
+  bc: ValidateFn<F2, FnValue<F1>>
+): StrictResultWithInput<F2, [F1, F2], EIn>;
+function pipeSideEffectStrict<
+  A,
+  F1 extends UnaryFn<A, any>,
+  F2 extends UnaryFn<FnValue<F1>, any>,
+  F3 extends UnaryFn<FnValue<F2>, any>
+>(
+  input: NonFunction<A>,
+  ab: ValidateFn<F1, A>,
+  bc: ValidateFn<F2, FnValue<F1>>,
+  cd: ValidateFn<F3, FnValue<F2>>
+): StrictResult<F3, [F1, F2, F3]>;
+function pipeSideEffectStrict<
+  A,
+  EIn,
+  F1 extends UnaryFn<A, any>,
+  F2 extends UnaryFn<FnValue<F1>, any>,
+  F3 extends UnaryFn<FnValue<F2>, any>
+>(
+  input: NonFunction<A> | SideEffect<EIn>,
+  ab: ValidateFn<F1, A>,
+  bc: ValidateFn<F2, FnValue<F1>>,
+  cd: ValidateFn<F3, FnValue<F2>>
+): StrictResultWithInput<F3, [F1, F2, F3], EIn>;
+function pipeSideEffectStrict<
+  A,
+  F1 extends UnaryFn<A, any>,
+  F2 extends UnaryFn<FnValue<F1>, any>,
+  F3 extends UnaryFn<FnValue<F2>, any>,
+  F4 extends UnaryFn<FnValue<F3>, any>
+>(
+  input: NonFunction<A>,
+  ab: ValidateFn<F1, A>,
+  bc: ValidateFn<F2, FnValue<F1>>,
+  cd: ValidateFn<F3, FnValue<F2>>,
+  de: ValidateFn<F4, FnValue<F3>>
+): StrictResult<F4, [F1, F2, F3, F4]>;
+function pipeSideEffectStrict<
+  A,
+  EIn,
+  F1 extends UnaryFn<A, any>,
+  F2 extends UnaryFn<FnValue<F1>, any>,
+  F3 extends UnaryFn<FnValue<F2>, any>,
+  F4 extends UnaryFn<FnValue<F3>, any>
+>(
+  input: NonFunction<A> | SideEffect<EIn>,
+  ab: ValidateFn<F1, A>,
+  bc: ValidateFn<F2, FnValue<F1>>,
+  cd: ValidateFn<F3, FnValue<F2>>,
+  de: ValidateFn<F4, FnValue<F3>>
+): StrictResultWithInput<F4, [F1, F2, F3, F4], EIn>;
+function pipeSideEffectStrict<
+  A,
+  F1 extends UnaryFn<A, any>,
+  F2 extends UnaryFn<FnValue<F1>, any>,
+  F3 extends UnaryFn<FnValue<F2>, any>,
+  F4 extends UnaryFn<FnValue<F3>, any>,
+  F5 extends UnaryFn<FnValue<F4>, any>
+>(
+  input: NonFunction<A>,
+  ab: ValidateFn<F1, A>,
+  bc: ValidateFn<F2, FnValue<F1>>,
+  cd: ValidateFn<F3, FnValue<F2>>,
+  de: ValidateFn<F4, FnValue<F3>>,
+  ef: ValidateFn<F5, FnValue<F4>>
+): StrictResult<F5, [F1, F2, F3, F4, F5]>;
+function pipeSideEffectStrict<
+  A,
+  EIn,
+  F1 extends UnaryFn<A, any>,
+  F2 extends UnaryFn<FnValue<F1>, any>,
+  F3 extends UnaryFn<FnValue<F2>, any>,
+  F4 extends UnaryFn<FnValue<F3>, any>,
+  F5 extends UnaryFn<FnValue<F4>, any>
+>(
+  input: NonFunction<A> | SideEffect<EIn>,
+  ab: ValidateFn<F1, A>,
+  bc: ValidateFn<F2, FnValue<F1>>,
+  cd: ValidateFn<F3, FnValue<F2>>,
+  de: ValidateFn<F4, FnValue<F3>>,
+  ef: ValidateFn<F5, FnValue<F4>>
+): StrictResultWithInput<F5, [F1, F2, F3, F4, F5], EIn>;
+function pipeSideEffectStrict<
+  A,
+  F1 extends UnaryFn<A, any>,
+  F2 extends UnaryFn<FnValue<F1>, any>,
+  F3 extends UnaryFn<FnValue<F2>, any>,
+  F4 extends UnaryFn<FnValue<F3>, any>,
+  F5 extends UnaryFn<FnValue<F4>, any>,
+  F6 extends UnaryFn<FnValue<F5>, any>
+>(
+  input: NonFunction<A>,
+  ab: ValidateFn<F1, A>,
+  bc: ValidateFn<F2, FnValue<F1>>,
+  cd: ValidateFn<F3, FnValue<F2>>,
+  de: ValidateFn<F4, FnValue<F3>>,
+  ef: ValidateFn<F5, FnValue<F4>>,
+  fg: ValidateFn<F6, FnValue<F5>>
+): StrictResult<F6, [F1, F2, F3, F4, F5, F6]>;
+function pipeSideEffectStrict<
+  A,
+  EIn,
+  F1 extends UnaryFn<A, any>,
+  F2 extends UnaryFn<FnValue<F1>, any>,
+  F3 extends UnaryFn<FnValue<F2>, any>,
+  F4 extends UnaryFn<FnValue<F3>, any>,
+  F5 extends UnaryFn<FnValue<F4>, any>,
+  F6 extends UnaryFn<FnValue<F5>, any>
+>(
+  input: NonFunction<A> | SideEffect<EIn>,
+  ab: ValidateFn<F1, A>,
+  bc: ValidateFn<F2, FnValue<F1>>,
+  cd: ValidateFn<F3, FnValue<F2>>,
+  de: ValidateFn<F4, FnValue<F3>>,
+  ef: ValidateFn<F5, FnValue<F4>>,
+  fg: ValidateFn<F6, FnValue<F5>>
+): StrictResultWithInput<F6, [F1, F2, F3, F4, F5, F6], EIn>;
+function pipeSideEffectStrict<
+  A,
+  F1 extends UnaryFn<A, any>,
+  F2 extends UnaryFn<FnValue<F1>, any>,
+  F3 extends UnaryFn<FnValue<F2>, any>,
+  F4 extends UnaryFn<FnValue<F3>, any>,
+  F5 extends UnaryFn<FnValue<F4>, any>,
+  F6 extends UnaryFn<FnValue<F5>, any>,
+  F7 extends UnaryFn<FnValue<F6>, any>
+>(
+  input: NonFunction<A>,
+  ab: ValidateFn<F1, A>,
+  bc: ValidateFn<F2, FnValue<F1>>,
+  cd: ValidateFn<F3, FnValue<F2>>,
+  de: ValidateFn<F4, FnValue<F3>>,
+  ef: ValidateFn<F5, FnValue<F4>>,
+  fg: ValidateFn<F6, FnValue<F5>>,
+  gh: ValidateFn<F7, FnValue<F6>>
+): StrictResult<F7, [F1, F2, F3, F4, F5, F6, F7]>;
+function pipeSideEffectStrict<
+  A,
+  EIn,
+  F1 extends UnaryFn<A, any>,
+  F2 extends UnaryFn<FnValue<F1>, any>,
+  F3 extends UnaryFn<FnValue<F2>, any>,
+  F4 extends UnaryFn<FnValue<F3>, any>,
+  F5 extends UnaryFn<FnValue<F4>, any>,
+  F6 extends UnaryFn<FnValue<F5>, any>,
+  F7 extends UnaryFn<FnValue<F6>, any>
+>(
+  input: NonFunction<A> | SideEffect<EIn>,
+  ab: ValidateFn<F1, A>,
+  bc: ValidateFn<F2, FnValue<F1>>,
+  cd: ValidateFn<F3, FnValue<F2>>,
+  de: ValidateFn<F4, FnValue<F3>>,
+  ef: ValidateFn<F5, FnValue<F4>>,
+  fg: ValidateFn<F6, FnValue<F5>>,
+  gh: ValidateFn<F7, FnValue<F6>>
+): StrictResultWithInput<F7, [F1, F2, F3, F4, F5, F6, F7], EIn>;
+function pipeSideEffectStrict<
+  A,
+  F1 extends UnaryFn<A, any>,
+  F2 extends UnaryFn<FnValue<F1>, any>,
+  F3 extends UnaryFn<FnValue<F2>, any>,
+  F4 extends UnaryFn<FnValue<F3>, any>,
+  F5 extends UnaryFn<FnValue<F4>, any>,
+  F6 extends UnaryFn<FnValue<F5>, any>,
+  F7 extends UnaryFn<FnValue<F6>, any>,
+  F8 extends UnaryFn<FnValue<F7>, any>
+>(
+  input: NonFunction<A>,
+  ab: ValidateFn<F1, A>,
+  bc: ValidateFn<F2, FnValue<F1>>,
+  cd: ValidateFn<F3, FnValue<F2>>,
+  de: ValidateFn<F4, FnValue<F3>>,
+  ef: ValidateFn<F5, FnValue<F4>>,
+  fg: ValidateFn<F6, FnValue<F5>>,
+  gh: ValidateFn<F7, FnValue<F6>>,
+  hi: ValidateFn<F8, FnValue<F7>>
+): StrictResult<F8, [F1, F2, F3, F4, F5, F6, F7, F8]>;
+function pipeSideEffectStrict<
+  A,
+  EIn,
+  F1 extends UnaryFn<A, any>,
+  F2 extends UnaryFn<FnValue<F1>, any>,
+  F3 extends UnaryFn<FnValue<F2>, any>,
+  F4 extends UnaryFn<FnValue<F3>, any>,
+  F5 extends UnaryFn<FnValue<F4>, any>,
+  F6 extends UnaryFn<FnValue<F5>, any>,
+  F7 extends UnaryFn<FnValue<F6>, any>,
+  F8 extends UnaryFn<FnValue<F7>, any>
+>(
+  input: NonFunction<A> | SideEffect<EIn>,
+  ab: ValidateFn<F1, A>,
+  bc: ValidateFn<F2, FnValue<F1>>,
+  cd: ValidateFn<F3, FnValue<F2>>,
+  de: ValidateFn<F4, FnValue<F3>>,
+  ef: ValidateFn<F5, FnValue<F4>>,
+  fg: ValidateFn<F6, FnValue<F5>>,
+  gh: ValidateFn<F7, FnValue<F6>>,
+  hi: ValidateFn<F8, FnValue<F7>>
+): StrictResultWithInput<F8, [F1, F2, F3, F4, F5, F6, F7, F8], EIn>;
+function pipeSideEffectStrict<
+  A,
+  F1 extends UnaryFn<A, any>,
+  F2 extends UnaryFn<FnValue<F1>, any>,
+  F3 extends UnaryFn<FnValue<F2>, any>,
+  F4 extends UnaryFn<FnValue<F3>, any>,
+  F5 extends UnaryFn<FnValue<F4>, any>,
+  F6 extends UnaryFn<FnValue<F5>, any>,
+  F7 extends UnaryFn<FnValue<F6>, any>,
+  F8 extends UnaryFn<FnValue<F7>, any>,
+  F9 extends UnaryFn<FnValue<F8>, any>
+>(
+  input: NonFunction<A>,
+  ab: ValidateFn<F1, A>,
+  bc: ValidateFn<F2, FnValue<F1>>,
+  cd: ValidateFn<F3, FnValue<F2>>,
+  de: ValidateFn<F4, FnValue<F3>>,
+  ef: ValidateFn<F5, FnValue<F4>>,
+  fg: ValidateFn<F6, FnValue<F5>>,
+  gh: ValidateFn<F7, FnValue<F6>>,
+  hi: ValidateFn<F8, FnValue<F7>>,
+  ij: ValidateFn<F9, FnValue<F8>>
+): StrictResult<F9, [F1, F2, F3, F4, F5, F6, F7, F8, F9]>;
+function pipeSideEffectStrict<
+  A,
+  EIn,
+  F1 extends UnaryFn<A, any>,
+  F2 extends UnaryFn<FnValue<F1>, any>,
+  F3 extends UnaryFn<FnValue<F2>, any>,
+  F4 extends UnaryFn<FnValue<F3>, any>,
+  F5 extends UnaryFn<FnValue<F4>, any>,
+  F6 extends UnaryFn<FnValue<F5>, any>,
+  F7 extends UnaryFn<FnValue<F6>, any>,
+  F8 extends UnaryFn<FnValue<F7>, any>,
+  F9 extends UnaryFn<FnValue<F8>, any>
+>(
+  input: NonFunction<A> | SideEffect<EIn>,
+  ab: ValidateFn<F1, A>,
+  bc: ValidateFn<F2, FnValue<F1>>,
+  cd: ValidateFn<F3, FnValue<F2>>,
+  de: ValidateFn<F4, FnValue<F3>>,
+  ef: ValidateFn<F5, FnValue<F4>>,
+  fg: ValidateFn<F6, FnValue<F5>>,
+  gh: ValidateFn<F7, FnValue<F6>>,
+  hi: ValidateFn<F8, FnValue<F7>>,
+  ij: ValidateFn<F9, FnValue<F8>>
+): StrictResultWithInput<F9, [F1, F2, F3, F4, F5, F6, F7, F8, F9], EIn>;
+function pipeSideEffectStrict<
+  A,
+  F1 extends UnaryFn<A, any>,
+  F2 extends UnaryFn<FnValue<F1>, any>,
+  F3 extends UnaryFn<FnValue<F2>, any>,
+  F4 extends UnaryFn<FnValue<F3>, any>,
+  F5 extends UnaryFn<FnValue<F4>, any>,
+  F6 extends UnaryFn<FnValue<F5>, any>,
+  F7 extends UnaryFn<FnValue<F6>, any>,
+  F8 extends UnaryFn<FnValue<F7>, any>,
+  F9 extends UnaryFn<FnValue<F8>, any>,
+  F10 extends UnaryFn<FnValue<F9>, any>
+>(
+  input: NonFunction<A>,
+  ab: ValidateFn<F1, A>,
+  bc: ValidateFn<F2, FnValue<F1>>,
+  cd: ValidateFn<F3, FnValue<F2>>,
+  de: ValidateFn<F4, FnValue<F3>>,
+  ef: ValidateFn<F5, FnValue<F4>>,
+  fg: ValidateFn<F6, FnValue<F5>>,
+  gh: ValidateFn<F7, FnValue<F6>>,
+  hi: ValidateFn<F8, FnValue<F7>>,
+  ij: ValidateFn<F9, FnValue<F8>>,
+  jk: ValidateFn<F10, FnValue<F9>>
+): StrictResult<F10, [F1, F2, F3, F4, F5, F6, F7, F8, F9, F10]>;
+function pipeSideEffectStrict<
+  A,
+  EIn,
+  F1 extends UnaryFn<A, any>,
+  F2 extends UnaryFn<FnValue<F1>, any>,
+  F3 extends UnaryFn<FnValue<F2>, any>,
+  F4 extends UnaryFn<FnValue<F3>, any>,
+  F5 extends UnaryFn<FnValue<F4>, any>,
+  F6 extends UnaryFn<FnValue<F5>, any>,
+  F7 extends UnaryFn<FnValue<F6>, any>,
+  F8 extends UnaryFn<FnValue<F7>, any>,
+  F9 extends UnaryFn<FnValue<F8>, any>,
+  F10 extends UnaryFn<FnValue<F9>, any>
+>(
+  input: NonFunction<A> | SideEffect<EIn>,
+  ab: ValidateFn<F1, A>,
+  bc: ValidateFn<F2, FnValue<F1>>,
+  cd: ValidateFn<F3, FnValue<F2>>,
+  de: ValidateFn<F4, FnValue<F3>>,
+  ef: ValidateFn<F5, FnValue<F4>>,
+  fg: ValidateFn<F6, FnValue<F5>>,
+  gh: ValidateFn<F7, FnValue<F6>>,
+  hi: ValidateFn<F8, FnValue<F7>>,
+  ij: ValidateFn<F9, FnValue<F8>>,
+  jk: ValidateFn<F10, FnValue<F9>>
+): StrictResultWithInput<F10, [F1, F2, F3, F4, F5, F6, F7, F8, F9, F10], EIn>;
+function pipeSideEffectStrict<A, Fns extends [UnaryFn<any, any>, ...UnaryFn<any, any>[]]>(
+  input: NonFunction<A>,
+  ...funcs: PipeCheckWithInput<A, Fns>
+): StrictResult<LastFn<Fns>, Fns>;
+function pipeSideEffectStrict<A, EIn, Fns extends [UnaryFn<any, any>, ...UnaryFn<any, any>[]]>(
+  input: NonFunction<A> | SideEffect<EIn>,
+  ...funcs: PipeCheckWithInput<A, Fns>
+): StrictResultWithInput<LastFn<Fns>, Fns, EIn>;
 
 function pipeSideEffectStrict<R>(ab: ZeroFn<R>): () => StrictResult<ZeroFn<R>, [ZeroFn<R>]>;
 function pipeSideEffectStrict<B, F2 extends UnaryFn<FnValue<ZeroFn<B>>, any>>(
@@ -471,8 +807,8 @@ function pipeSideEffectStrict<Fns extends [FromFn<any>, ...UnaryFn<any, any>[]]>
 function pipeSideEffectStrict<Fns extends [UnaryFn<any, any>, ...UnaryFn<any, any>[]]>(
   ...funcs: PipeCheck<Fns>
 ): PipeSideEffectStrict<Fns>;
-function pipeSideEffectStrict(...funcs: Array<(input: any) => any>) {
-  return (init?: any) => {
+function pipeSideEffectStrict(...args: Array<any>) {
+  const run = (init: any, funcs: Array<(input: any) => any>) => {
     let acc = init;
     for (const fn of funcs) {
       if (isSideEffect(acc)) {
@@ -482,6 +818,17 @@ function pipeSideEffectStrict(...funcs: Array<(input: any) => any>) {
     }
     return acc;
   };
+
+  if (args.length === 0) {
+    return undefined;
+  }
+  const [input, ...rest] = args as [any, ...Array<(input: any) => any>];
+  if (typeof input === 'function') {
+    const funcs = [input, ...rest];
+    return (init?: any) => run(init, funcs);
+  }
+
+  return run(input, rest);
 }
 
 export default pipeSideEffectStrict;


### PR DESCRIPTION

  - Documented hybrid pipe behavior (value‑first executes immediately, function‑first returns a reusable pipeline)
  - Updated guide and examples to prefer value‑first for better inference, with from() for zero‑arg pipelines
  - Aligned SideEffect/async pipe examples with the value‑first pattern