### PR TITLE
chore(docs): migrate skills to folder-based package

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,9 +166,9 @@ yarn add fp-pack
 
 ## AI Agent Skills (Optional)
 
-fp-pack includes an AI agent skills file that helps AI coding assistants (Claude Code, GitHub Copilot, Cursor, etc.) automatically write fp-pack-style functional code.
+fp-pack includes an AI agent skills package that helps AI coding assistants (Claude Code, GitHub Copilot, Cursor, etc.) automatically write fp-pack-style functional code.
 
-When you have this skills file in your project, AI assistants will:
+When you have this skills package in your project, AI assistants will:
 - Default to using `pipe`/`pipeAsync` for pure transformations, and `pipeSideEffect`/`pipeAsyncSideEffect` when SideEffect is involved (use strict variants when you need strict effect unions)
 - Use the `SideEffect` pattern instead of try-catch
 - Prefer `stream/*` functions for large datasets
@@ -176,19 +176,23 @@ When you have this skills file in your project, AI assistants will:
 
 ### Setup for Claude Code
 
-Copy the skills file to your project's `.claude/skills/` directory:
+Copy the skills folder to your project's `.claude/skills/` directory:
 
 ```bash
 # Unix/macOS/Linux
-cp node_modules/fp-pack/dist/skills/fp-pack.md .claude/skills/
+mkdir -p .claude/skills/fp-pack
+cp -R node_modules/fp-pack/dist/skills/fp-pack/* .claude/skills/fp-pack/
 
 # Windows (PowerShell)
-Copy-Item node_modules/fp-pack/dist/skills/fp-pack.md .claude/skills/
+New-Item -ItemType Directory -Force -Path .claude/skills/fp-pack
+Copy-Item node_modules/fp-pack/dist/skills/fp-pack/* .claude/skills/fp-pack -Recurse
 
 # Or manually create the directory and copy
-mkdir -p .claude/skills
-cp node_modules/fp-pack/dist/skills/fp-pack.md .claude/skills/
+mkdir -p .claude/skills/fp-pack
+cp -R node_modules/fp-pack/dist/skills/fp-pack/* .claude/skills/fp-pack/
 ```
+
+If your tool expects a single file, point it to `.claude/skills/fp-pack/SKILL.md` or link that file to `.claude/skills/fp-pack.md`.
 
 ### Setup for Codex
 
@@ -197,22 +201,22 @@ Copy the Codex skill to your project's `$CODEX_HOME/skills/` directory (default:
 ```bash
 # Unix/macOS/Linux
 mkdir -p ~/.codex/skills/fp-pack
-cp node_modules/fp-pack/dist/skills/fp-pack/SKILL.md ~/.codex/skills/fp-pack/SKILL.md
+cp -R node_modules/fp-pack/dist/skills/fp-pack/* ~/.codex/skills/fp-pack/
 
 # Windows (PowerShell)
 New-Item -ItemType Directory -Force -Path "$HOME/.codex/skills/fp-pack"
-Copy-Item node_modules/fp-pack/dist/skills/fp-pack/SKILL.md $HOME/.codex/skills/fp-pack/SKILL.md
+Copy-Item node_modules/fp-pack/dist/skills/fp-pack/* $HOME/.codex/skills/fp-pack -Recurse
 ```
 
 Once configured, AI assistants will automatically apply fp-pack coding patterns when helping you write code.
 
-> **Note:** The skills file is located at `node_modules/fp-pack/dist/skills/fp-pack.md` after installation. You can also view it in the [GitHub repository](https://github.com/superlucky84/fp-pack/blob/main/fp-pack.md).
+> **Note:** The skills package is located at `node_modules/fp-pack/dist/skills/fp-pack/` after installation (includes `SKILL.md`, `examples/`, `reference/`, and `constraints/`). You can also view `SKILL.md` in the [GitHub repository](https://github.com/superlucky84/fp-pack/blob/main/skills/fp-pack/SKILL.md).
 
 ### AI Agent Role Add-on (Global)
 
 For agents with system prompt support (OpenCode, custom agents), fp-pack provides a **reusable behavior module** that conditionally enforces fp-pack patterns when fp-pack is detected in the project.
 
-Unlike skills files which are project-specific, this add-on is attached directly to your agent's system prompt, making it work across all your projects. It automatically activates only when fp-pack is installed.
+Unlike skills packages which are project-specific, this add-on is attached directly to your agent's system prompt, making it work across all your projects. It automatically activates only when fp-pack is installed.
 
 📖 **[View AI Agent Role Add-on Documentation](https://superlucky84.github.io/fp-pack/#/ai-agent-addon)**
 

--- a/docs/src/pages/AIAgentAddon.tsx
+++ b/docs/src/pages/AIAgentAddon.tsx
@@ -94,7 +94,7 @@ When existing code could be improved with fp-pack:
 REFERENCE MATERIALS (NOT PART OF BEHAVIORAL RULES):
 
 For detailed guidance on fp-pack patterns and usage, refer to:
-node_modules/fp-pack/dist/skills/fp-pack.md
+node_modules/fp-pack/dist/skills/fp-pack/
 
 This reference material provides comprehensive examples, troubleshooting tips,
 and pattern guidance that complements the behavioral guidelines above.`;
@@ -125,7 +125,7 @@ export const AIAgentAddon = () => (
     </h2>
 
     <p class="text-sm md:text-base text-gray-700 dark:text-gray-300 leading-relaxed mb-6">
-      The fp-pack Agent Role Add-on is a copy-paste ready behavior extension for AI coding agents (OpenCode, custom agents, IDE extensions, etc.). Unlike skills files that are project-specific, this add-on is attached directly to your agent's system prompt, making it work across all your projects.
+      The fp-pack Agent Role Add-on is a copy-paste ready behavior extension for AI coding agents (OpenCode, custom agents, IDE extensions, etc.). Unlike skills packages that are project-specific, this add-on is attached directly to your agent's system prompt, making it work across all your projects.
     </p>
 
     <div class="bg-blue-50 dark:bg-blue-900/20 p-6 rounded-lg border border-blue-200 dark:border-blue-800 mb-6">

--- a/docs/src/pages/AIAgentAddon_ko.tsx
+++ b/docs/src/pages/AIAgentAddon_ko.tsx
@@ -94,7 +94,7 @@ When existing code could be improved with fp-pack:
 REFERENCE MATERIALS (NOT PART OF BEHAVIORAL RULES):
 
 For detailed guidance on fp-pack patterns and usage, refer to:
-node_modules/fp-pack/dist/skills/fp-pack.md
+node_modules/fp-pack/dist/skills/fp-pack/
 
 This reference material provides comprehensive examples, troubleshooting tips,
 and pattern guidance that complements the behavioral guidelines above.`;
@@ -125,7 +125,7 @@ export const AIAgentAddon_ko = () => (
     </h2>
 
     <p class="text-sm md:text-base text-gray-700 dark:text-gray-300 leading-relaxed mb-6">
-      fp-pack Agent Role Add-on은 AI 코딩 에이전트(OpenCode, 커스텀 에이전트, IDE 확장 등)를 위한 복사-붙여넣기 가능한 행동 확장입니다. 프로젝트별 설정인 skills 파일과 달리, 이 add-on은 에이전트의 시스템 프롬프트에 직접 추가되어 모든 프로젝트에서 작동합니다.
+      fp-pack Agent Role Add-on은 AI 코딩 에이전트(OpenCode, 커스텀 에이전트, IDE 확장 등)를 위한 복사-붙여넣기 가능한 행동 확장입니다. 프로젝트별 설정인 skills 패키지와 달리, 이 add-on은 에이전트의 시스템 프롬프트에 직접 추가되어 모든 프로젝트에서 작동합니다.
     </p>
 
     <div class="bg-blue-50 dark:bg-blue-900/20 p-6 rounded-lg border border-blue-200 dark:border-blue-800 mb-6">

--- a/docs/src/pages/AIAgentSkills.tsx
+++ b/docs/src/pages/AIAgentSkills.tsx
@@ -26,11 +26,11 @@ export const AIAgentSkills = () => (
     </h2>
 
     <p class="text-sm md:text-base text-gray-700 dark:text-gray-300 leading-relaxed mb-6">
-      fp-pack includes an AI agent skills file that helps AI coding assistants (Claude Code, GitHub Copilot, Cursor, etc.) automatically write fp-pack-style functional code.
+      fp-pack includes an AI agent skills package that helps AI coding assistants (Claude Code, GitHub Copilot, Cursor, etc.) automatically write fp-pack-style functional code.
     </p>
 
     <p class="text-sm md:text-base text-gray-700 dark:text-gray-300 leading-relaxed mb-6">
-      When you have this skills file in your project, AI assistants will:
+      When you have this skills package in your project, AI assistants will:
     </p>
 
     <ul class="list-disc list-inside space-y-2 text-sm md:text-base text-gray-700 dark:text-gray-300 mb-6">
@@ -50,21 +50,27 @@ export const AIAgentSkills = () => (
     </h2>
 
     <p class="text-sm md:text-base text-gray-700 dark:text-gray-300 leading-relaxed mb-6">
-      Copy the skills file to your project's <code class="text-sm">.claude/skills/</code> directory:
+      Copy the skills folder to your project's <code class="text-sm">.claude/skills/</code> directory:
     </p>
 
     <CodeBlock
       language="bash"
       code={`# Unix/macOS/Linux
-cp node_modules/fp-pack/dist/skills/fp-pack.md .claude/skills/
+mkdir -p .claude/skills/fp-pack
+cp -R node_modules/fp-pack/dist/skills/fp-pack/* .claude/skills/fp-pack/
 
 # Windows (PowerShell)
-Copy-Item node_modules/fp-pack/dist/skills/fp-pack.md .claude/skills/
+New-Item -ItemType Directory -Force -Path .claude/skills/fp-pack
+Copy-Item node_modules/fp-pack/dist/skills/fp-pack/* .claude/skills/fp-pack -Recurse
 
 # Or manually create the directory and copy
-mkdir -p .claude/skills
-cp node_modules/fp-pack/dist/skills/fp-pack.md .claude/skills/`}
+mkdir -p .claude/skills/fp-pack
+cp -R node_modules/fp-pack/dist/skills/fp-pack/* .claude/skills/fp-pack/`}
     />
+
+    <p class="text-sm md:text-base text-gray-700 dark:text-gray-300 leading-relaxed mb-6">
+      If your tool expects a single file, point it to <code class="text-sm">.claude/skills/fp-pack/SKILL.md</code> or link that file to <code class="text-sm">.claude/skills/fp-pack.md</code>.
+    </p>
 
     <hr class="border-t border-gray-200 dark:border-gray-700 my-10" />
 
@@ -80,11 +86,11 @@ cp node_modules/fp-pack/dist/skills/fp-pack.md .claude/skills/`}
       language="bash"
       code={`# Unix/macOS/Linux
 mkdir -p ~/.codex/skills/fp-pack
-cp node_modules/fp-pack/dist/skills/fp-pack/SKILL.md ~/.codex/skills/fp-pack/SKILL.md
+cp -R node_modules/fp-pack/dist/skills/fp-pack/* ~/.codex/skills/fp-pack/
 
 # Windows (PowerShell)
 New-Item -ItemType Directory -Force -Path "$HOME/.codex/skills/fp-pack"
-Copy-Item node_modules/fp-pack/dist/skills/fp-pack/SKILL.md $HOME/.codex/skills/fp-pack/SKILL.md`}
+Copy-Item node_modules/fp-pack/dist/skills/fp-pack/* $HOME/.codex/skills/fp-pack -Recurse`}
     />
 
     <hr class="border-t border-gray-200 dark:border-gray-700 my-10" />
@@ -94,7 +100,7 @@ Copy-Item node_modules/fp-pack/dist/skills/fp-pack/SKILL.md $HOME/.codex/skills/
     </h2>
 
     <p class="text-sm md:text-base text-gray-700 dark:text-gray-300 leading-relaxed mb-6">
-      For better reliability, create a <code class="text-sm">CLAUDE.md</code> file in your project root. This ensures AI agents read the fp-pack skills file before writing code.
+      For better reliability, create a <code class="text-sm">CLAUDE.md</code> file in your project root. This ensures AI agents read the fp-pack skills package before writing code.
     </p>
 
     <CodeBlock
@@ -105,7 +111,7 @@ Copy-Item node_modules/fp-pack/dist/skills/fp-pack/SKILL.md $HOME/.codex/skills/
 
 **Before writing ANY code, you MUST:**
 
-1. Read \`.claude/skills/fp-pack.md\` **completely**
+1. Read \`.claude/skills/fp-pack/SKILL.md\` **completely**
 2. Follow the anti-patterns section **strictly**
 3. Use the patterns shown in real-world examples
 
@@ -177,13 +183,13 @@ const results = processUsers(users);`}
     </h2>
 
     <p class="text-sm md:text-base text-gray-700 dark:text-gray-300 leading-relaxed mb-6">
-      The skills file is located at <code class="text-sm">node_modules/fp-pack/dist/skills/fp-pack.md</code> after installation.
+      The skills package is located at <code class="text-sm">node_modules/fp-pack/dist/skills/fp-pack/</code> after installation (includes <code class="text-sm">SKILL.md</code>, <code class="text-sm">examples/</code>, <code class="text-sm">reference/</code>, and <code class="text-sm">constraints/</code>).
     </p>
 
     <p class="text-sm md:text-base text-gray-700 dark:text-gray-300 leading-relaxed mb-6">
       You can also view it in the{' '}
       <a
-        href="https://github.com/superlucky84/fp-pack/blob/main/fp-pack.md"
+        href="https://github.com/superlucky84/fp-pack/blob/main/skills/fp-pack/SKILL.md"
         target="_blank"
         rel="noopener noreferrer"
         class="text-blue-600 dark:text-blue-400 hover:underline"
@@ -194,7 +200,7 @@ const results = processUsers(users);`}
 
     <div class="bg-blue-50 dark:bg-blue-900/20 p-6 rounded-lg border border-blue-200 dark:border-blue-800 mt-6">
       <p class="text-sm md:text-base text-blue-900 dark:text-blue-200 leading-relaxed">
-        <span class="font-medium">💡 Tip:</span> After setting up the skills file, you can ask your AI assistant questions like "refactor this code using fp-pack" or "write this function using pipe and map", and it will automatically apply the patterns.
+        <span class="font-medium">💡 Tip:</span> After setting up the skills package, you can ask your AI assistant questions like "refactor this code using fp-pack" or "write this function using pipe and map", and it will automatically apply the patterns.
       </p>
     </div>
   </div>

--- a/docs/src/pages/AIAgentSkills_ko.tsx
+++ b/docs/src/pages/AIAgentSkills_ko.tsx
@@ -26,11 +26,11 @@ export const AIAgentSkills_ko = () => (
     </h2>
 
     <p class="text-sm md:text-base text-gray-700 dark:text-gray-300 leading-relaxed mb-6">
-      fp-pack에는 AI 코딩 어시스턴트(Claude Code, GitHub Copilot, Cursor 등)가 자동으로 fp-pack 스타일의 함수형 코드를 작성하도록 돕는 AI agent skills 파일이 포함되어 있습니다.
+      fp-pack에는 AI 코딩 어시스턴트(Claude Code, GitHub Copilot, Cursor 등)가 자동으로 fp-pack 스타일의 함수형 코드를 작성하도록 돕는 AI 에이전트 스킬 패키지가 포함되어 있습니다.
     </p>
 
     <p class="text-sm md:text-base text-gray-700 dark:text-gray-300 leading-relaxed mb-6">
-      프로젝트에 이 skills 파일이 있으면 AI 어시스턴트가:
+      프로젝트에 이 스킬 패키지가 있으면 AI 어시스턴트가:
     </p>
 
     <ul class="list-disc list-inside space-y-2 text-sm md:text-base text-gray-700 dark:text-gray-300 mb-6">
@@ -50,21 +50,27 @@ export const AIAgentSkills_ko = () => (
     </h2>
 
     <p class="text-sm md:text-base text-gray-700 dark:text-gray-300 leading-relaxed mb-6">
-      skills 파일을 프로젝트의 <code class="text-sm">.claude/skills/</code> 디렉토리로 복사하세요:
+      skills 폴더를 프로젝트의 <code class="text-sm">.claude/skills/</code> 디렉토리로 복사하세요:
     </p>
 
     <CodeBlock
       language="bash"
       code={`# Unix/macOS/Linux
-cp node_modules/fp-pack/dist/skills/fp-pack.md .claude/skills/
+mkdir -p .claude/skills/fp-pack
+cp -R node_modules/fp-pack/dist/skills/fp-pack/* .claude/skills/fp-pack/
 
 # Windows (PowerShell)
-Copy-Item node_modules/fp-pack/dist/skills/fp-pack.md .claude/skills/
+New-Item -ItemType Directory -Force -Path .claude/skills/fp-pack
+Copy-Item node_modules/fp-pack/dist/skills/fp-pack/* .claude/skills/fp-pack -Recurse
 
 # 또는 수동으로 디렉토리를 만들고 복사
-mkdir -p .claude/skills
-cp node_modules/fp-pack/dist/skills/fp-pack.md .claude/skills/`}
+mkdir -p .claude/skills/fp-pack
+cp -R node_modules/fp-pack/dist/skills/fp-pack/* .claude/skills/fp-pack/`}
     />
+
+    <p class="text-sm md:text-base text-gray-700 dark:text-gray-300 leading-relaxed mb-6">
+      단일 파일만 허용하는 도구라면 <code class="text-sm">.claude/skills/fp-pack/SKILL.md</code>를 가리키거나, 해당 파일을 <code class="text-sm">.claude/skills/fp-pack.md</code>로 링크하세요.
+    </p>
 
     <hr class="border-t border-gray-200 dark:border-gray-700 my-10" />
 
@@ -80,11 +86,11 @@ cp node_modules/fp-pack/dist/skills/fp-pack.md .claude/skills/`}
       language="bash"
       code={`# Unix/macOS/Linux
 mkdir -p ~/.codex/skills/fp-pack
-cp node_modules/fp-pack/dist/skills/fp-pack/SKILL.md ~/.codex/skills/fp-pack/SKILL.md
+cp -R node_modules/fp-pack/dist/skills/fp-pack/* ~/.codex/skills/fp-pack/
 
 # Windows (PowerShell)
 New-Item -ItemType Directory -Force -Path "$HOME/.codex/skills/fp-pack"
-Copy-Item node_modules/fp-pack/dist/skills/fp-pack/SKILL.md $HOME/.codex/skills/fp-pack/SKILL.md`}
+Copy-Item node_modules/fp-pack/dist/skills/fp-pack/* $HOME/.codex/skills/fp-pack -Recurse`}
     />
 
     <hr class="border-t border-gray-200 dark:border-gray-700 my-10" />
@@ -94,7 +100,7 @@ Copy-Item node_modules/fp-pack/dist/skills/fp-pack/SKILL.md $HOME/.codex/skills/
     </h2>
 
     <p class="text-sm md:text-base text-gray-700 dark:text-gray-300 leading-relaxed mb-6">
-      더 안정적인 동작을 위해 프로젝트 루트에 <code class="text-sm">CLAUDE.md</code> 파일을 생성하세요. 이렇게 하면 AI 에이전트가 코드를 작성하기 전에 fp-pack skills 파일을 읽도록 보장할 수 있습니다.
+      더 안정적인 동작을 위해 프로젝트 루트에 <code class="text-sm">CLAUDE.md</code> 파일을 생성하세요. 이렇게 하면 AI 에이전트가 코드를 작성하기 전에 fp-pack 스킬 패키지를 읽도록 보장할 수 있습니다.
     </p>
 
     <CodeBlock
@@ -105,7 +111,7 @@ Copy-Item node_modules/fp-pack/dist/skills/fp-pack/SKILL.md $HOME/.codex/skills/
 
 **코드를 작성하기 전에 반드시:**
 
-1. \`.claude/skills/fp-pack.md\` 파일을 **완전히** 읽어야 합니다
+1. \`.claude/skills/fp-pack/SKILL.md\` 파일을 **완전히** 읽어야 합니다
 2. 안티패턴 섹션을 **엄격하게** 따라야 합니다
 3. 실전 예제에 나온 패턴을 사용해야 합니다
 
@@ -177,13 +183,13 @@ const results = processUsers(users);`}
     </h2>
 
     <p class="text-sm md:text-base text-gray-700 dark:text-gray-300 leading-relaxed mb-6">
-      설치 후 skills 파일은 <code class="text-sm">node_modules/fp-pack/dist/skills/fp-pack.md</code>에 있습니다.
+      설치 후 스킬 패키지는 <code class="text-sm">node_modules/fp-pack/dist/skills/fp-pack/</code>에 있습니다 (여기에는 <code class="text-sm">SKILL.md</code>, <code class="text-sm">examples/</code>, <code class="text-sm">reference/</code>, <code class="text-sm">constraints/</code>가 포함됩니다).
     </p>
 
     <p class="text-sm md:text-base text-gray-700 dark:text-gray-300 leading-relaxed mb-6">
       {' '}
       <a
-        href="https://github.com/superlucky84/fp-pack/blob/main/fp-pack.md"
+        href="https://github.com/superlucky84/fp-pack/blob/main/skills/fp-pack/SKILL.md"
         target="_blank"
         rel="noopener noreferrer"
         class="text-blue-600 dark:text-blue-400 hover:underline"
@@ -195,7 +201,7 @@ const results = processUsers(users);`}
 
     <div class="bg-blue-50 dark:bg-blue-900/20 p-6 rounded-lg border border-blue-200 dark:border-blue-800 mt-6">
       <p class="text-sm md:text-base text-blue-900 dark:text-blue-200 leading-relaxed">
-        <span class="font-medium">💡 팁:</span> skills 파일을 설정한 후 "이 코드를 fp-pack으로 리팩토링해줘" 또는 "pipe와 map을 사용해서 이 함수를 작성해줘"와 같이 AI 어시스턴트에게 질문하면 자동으로 패턴을 적용해줍니다.
+        <span class="font-medium">💡 팁:</span> 스킬 패키지를 설정한 후 "이 코드를 fp-pack으로 리팩토링해줘" 또는 "pipe와 map을 사용해서 이 함수를 작성해줘"와 같이 AI 어시스턴트에게 질문하면 자동으로 패턴을 적용해줍니다.
       </p>
     </div>
   </div>

--- a/docs/src/pages/Home.tsx
+++ b/docs/src/pages/Home.tsx
@@ -307,7 +307,7 @@ const result = runPipeResult(
     </h2>
 
     <p class="text-gray-700 dark:text-gray-300 mb-4">
-      fp-pack includes an AI agent skills file that helps AI coding assistants (Claude Code, GitHub Copilot, Cursor, etc.) automatically write fp-pack-style functional code.
+      fp-pack includes an AI agent skills package that helps AI coding assistants (Claude Code, GitHub Copilot, Cursor, etc.) automatically write fp-pack-style functional code.
     </p>
 
     <div class="border-l-4 border-green-500 bg-green-50 dark:bg-green-900/20 p-4 md:p-6 mb-6 rounded-r">
@@ -339,7 +339,7 @@ const result = runPipeResult(
     </h3>
 
     <p class="text-sm md:text-base text-gray-700 dark:text-gray-300 mb-4">
-      If your AI coding assistant supports skills files, copy <code class="text-xs md:text-sm bg-gray-200 dark:bg-gray-700 px-2 py-1 rounded">fp-pack.md</code> to the appropriate directory.
+      If your AI coding assistant supports skills packages, copy the <code class="text-xs md:text-sm bg-gray-200 dark:bg-gray-700 px-2 py-1 rounded">skills/fp-pack</code> folder to the appropriate directory.
     </p>
 
     <p class="text-sm md:text-base text-gray-700 dark:text-gray-300 mb-4">
@@ -349,15 +349,21 @@ const result = runPipeResult(
     <CodeBlock
       language="bash"
       code={`# Unix/macOS/Linux
-cp node_modules/fp-pack/dist/skills/fp-pack.md .claude/skills/
+mkdir -p .claude/skills/fp-pack
+cp -R node_modules/fp-pack/dist/skills/fp-pack/* .claude/skills/fp-pack/
 
 # Windows (PowerShell)
-Copy-Item node_modules/fp-pack/dist/skills/fp-pack.md .claude/skills/
+New-Item -ItemType Directory -Force -Path .claude/skills/fp-pack
+Copy-Item node_modules/fp-pack/dist/skills/fp-pack/* .claude/skills/fp-pack -Recurse
 
 # Or manually create the directory and copy
-mkdir -p .claude/skills
-cp node_modules/fp-pack/dist/skills/fp-pack.md .claude/skills/`}
+mkdir -p .claude/skills/fp-pack
+cp -R node_modules/fp-pack/dist/skills/fp-pack/* .claude/skills/fp-pack/`}
     />
+
+    <p class="text-sm md:text-base text-gray-700 dark:text-gray-300 mt-3 mb-4">
+      If your tool expects a single file, point it to <code class="text-xs md:text-sm bg-gray-200 dark:bg-gray-700 px-2 py-1 rounded">.claude/skills/fp-pack/SKILL.md</code> or link it as <code class="text-xs md:text-sm bg-gray-200 dark:bg-gray-700 px-2 py-1 rounded">.claude/skills/fp-pack.md</code>.
+    </p>
 
     <p class="text-sm md:text-base text-gray-700 dark:text-gray-300 mb-4">
       <strong>For Codex:</strong> Copy to <code class="text-xs md:text-sm bg-gray-200 dark:bg-gray-700 px-2 py-1 rounded">~/.codex/skills/fp-pack/</code>
@@ -367,11 +373,11 @@ cp node_modules/fp-pack/dist/skills/fp-pack.md .claude/skills/`}
       language="bash"
       code={`# Unix/macOS/Linux
 mkdir -p ~/.codex/skills/fp-pack
-cp node_modules/fp-pack/dist/skills/fp-pack/SKILL.md ~/.codex/skills/fp-pack/SKILL.md
+cp -R node_modules/fp-pack/dist/skills/fp-pack/* ~/.codex/skills/fp-pack/
 
 # Windows (PowerShell)
 New-Item -ItemType Directory -Force -Path "$HOME/.codex/skills/fp-pack"
-Copy-Item node_modules/fp-pack/dist/skills/fp-pack/SKILL.md $HOME/.codex/skills/fp-pack/SKILL.md`}
+Copy-Item node_modules/fp-pack/dist/skills/fp-pack/* $HOME/.codex/skills/fp-pack -Recurse`}
     />
 
     <p class="text-sm md:text-base text-gray-700 dark:text-gray-300 mt-4 mb-2">

--- a/docs/src/pages/Home_ko.tsx
+++ b/docs/src/pages/Home_ko.tsx
@@ -307,7 +307,7 @@ const result = runPipeResult(
     </h2>
 
     <p class="text-gray-700 dark:text-gray-300 mb-4">
-      fp-pack은 AI 코딩 어시스턴트(Claude Code, GitHub Copilot, Cursor 등)가 자동으로 fp-pack 스타일의 함수형 코드를 작성하도록 돕는 스킬 파일을 포함합니다.
+      fp-pack은 AI 코딩 어시스턴트(Claude Code, GitHub Copilot, Cursor 등)가 자동으로 fp-pack 스타일의 함수형 코드를 작성하도록 돕는 스킬 패키지를 포함합니다.
     </p>
 
     <div class="border-l-4 border-green-500 bg-green-50 dark:bg-green-900/20 p-4 md:p-6 mb-6 rounded-r">
@@ -339,7 +339,7 @@ const result = runPipeResult(
     </h3>
 
     <p class="text-sm md:text-base text-gray-700 dark:text-gray-300 mb-4">
-      AI 코딩 어시스턴트가 스킬 파일을 지원한다면, <code class="text-xs md:text-sm bg-gray-200 dark:bg-gray-700 px-2 py-1 rounded">fp-pack.md</code>를 적절한 디렉토리에 복사하세요.
+      AI 코딩 어시스턴트가 스킬 패키지를 지원한다면, <code class="text-xs md:text-sm bg-gray-200 dark:bg-gray-700 px-2 py-1 rounded">skills/fp-pack</code> 폴더를 적절한 디렉토리에 복사하세요.
     </p>
 
     <p class="text-sm md:text-base text-gray-700 dark:text-gray-300 mb-4">
@@ -349,15 +349,21 @@ const result = runPipeResult(
     <CodeBlock
       language="bash"
       code={`# Unix/macOS/Linux
-cp node_modules/fp-pack/dist/skills/fp-pack.md .claude/skills/
+mkdir -p .claude/skills/fp-pack
+cp -R node_modules/fp-pack/dist/skills/fp-pack/* .claude/skills/fp-pack/
 
 # Windows (PowerShell)
-Copy-Item node_modules/fp-pack/dist/skills/fp-pack.md .claude/skills/
+New-Item -ItemType Directory -Force -Path .claude/skills/fp-pack
+Copy-Item node_modules/fp-pack/dist/skills/fp-pack/* .claude/skills/fp-pack -Recurse
 
 # 또는 수동으로 디렉토리 생성 후 복사
-mkdir -p .claude/skills
-cp node_modules/fp-pack/dist/skills/fp-pack.md .claude/skills/`}
+mkdir -p .claude/skills/fp-pack
+cp -R node_modules/fp-pack/dist/skills/fp-pack/* .claude/skills/fp-pack/`}
     />
+
+    <p class="text-sm md:text-base text-gray-700 dark:text-gray-300 mt-3 mb-4">
+      단일 파일만 허용하는 도구라면 <code class="text-xs md:text-sm bg-gray-200 dark:bg-gray-700 px-2 py-1 rounded">.claude/skills/fp-pack/SKILL.md</code>를 가리키거나, 해당 파일을 <code class="text-xs md:text-sm bg-gray-200 dark:bg-gray-700 px-2 py-1 rounded">.claude/skills/fp-pack.md</code>로 링크하세요.
+    </p>
 
     <p class="text-sm md:text-base text-gray-700 dark:text-gray-300 mb-4">
       <strong>Codex의 경우:</strong> <code class="text-xs md:text-sm bg-gray-200 dark:bg-gray-700 px-2 py-1 rounded">~/.codex/skills/fp-pack/</code>에 복사
@@ -367,11 +373,11 @@ cp node_modules/fp-pack/dist/skills/fp-pack.md .claude/skills/`}
       language="bash"
       code={`# Unix/macOS/Linux
 mkdir -p ~/.codex/skills/fp-pack
-cp node_modules/fp-pack/dist/skills/fp-pack/SKILL.md ~/.codex/skills/fp-pack/SKILL.md
+cp -R node_modules/fp-pack/dist/skills/fp-pack/* ~/.codex/skills/fp-pack/
 
 # Windows (PowerShell)
 New-Item -ItemType Directory -Force -Path "$HOME/.codex/skills/fp-pack"
-Copy-Item node_modules/fp-pack/dist/skills/fp-pack/SKILL.md $HOME/.codex/skills/fp-pack/SKILL.md`}
+Copy-Item node_modules/fp-pack/dist/skills/fp-pack/* $HOME/.codex/skills/fp-pack -Recurse`}
     />
 
     <p class="text-sm md:text-base text-gray-700 dark:text-gray-300 mt-4 mb-2">

--- a/fp-pack-agent-addon.md
+++ b/fp-pack-agent-addon.md
@@ -135,7 +135,7 @@ When existing code could be improved with fp-pack:
 REFERENCE MATERIALS (NOT PART OF BEHAVIORAL RULES):
 
 For detailed guidance on fp-pack patterns and usage, refer to:
-node_modules/fp-pack/dist/skills/fp-pack.md
+node_modules/fp-pack/dist/skills/fp-pack/
 
 This reference material provides comprehensive examples, troubleshooting tips,
 and pattern guidance that complements the behavioral guidelines above.
@@ -265,7 +265,7 @@ fp-pack patterns benefit from guidance because:
 
 ### Balanced Approach
 
-This add-on follows fp-pack.md's philosophy:
+This add-on follows the fp-pack SKILL.md philosophy:
 - "Use pipe for 2+ steps; for single steps, call the function directly"
 - "For trivial one-liners, using native JS directly is fine"
 - "Reach for fp-pack when composition adds clarity or reuse"
@@ -297,7 +297,7 @@ This detection-based activation allows a single agent configuration to work appr
 ### Design Constraints
 
 This add-on intentionally avoids:
-- **Complete API coverage**: Full API documentation belongs in separate references (fp-pack.md)
+- **Complete API coverage**: Full API documentation belongs in separate references (skills/fp-pack/ reference files)
 - **Framework-specific patterns**: UI framework integration belongs in project-specific documentation
 - **Implementation details**: Internal fp-pack architecture is irrelevant to usage
 - **Absolute prohibitions**: "Never" statements reduce flexibility and pragmatism

--- a/skills/fp-pack/SKILL.md
+++ b/skills/fp-pack/SKILL.md
@@ -1,6 +1,19 @@
+---
+name: fp-pack
+description: Use when working in projects that use fp-pack; follow pipe, SideEffect, and curry guidelines.
+metadata:
+  short-description: fp-pack workflow
+  version: {{version}}
+---
+
 # fp-pack AI Agent Skills
 
 Document Version: {{version}}
+
+Additional materials (optional):
+- constraints/ (rules, mistakes, troubleshooting)
+- reference/ (composition, currying, TypeScript inference)
+- examples/ (quick examples)
 
 ## ⚠️ Activation Condition (Read First)
 

--- a/skills/fp-pack/constraints/common-mistakes.md
+++ b/skills/fp-pack/constraints/common-mistakes.md
@@ -1,0 +1,44 @@
+# Common Mistakes and Fixes
+
+## Do not wrap data in zero-arg functions
+
+```ts
+// BAD
+pipe(() => [1, 2, 3], filter((n: number) => n % 2 === 0));
+
+// GOOD (value-first)
+pipe([1, 2, 3], filter((n: number) => n % 2 === 0));
+
+// GOOD (no-input pipeline)
+pipe(from([1, 2, 3]), filter((n: number) => n % 2 === 0))();
+```
+
+## `ifElse`/`cond` need total branches
+
+```ts
+const status = ifElse((n: number) => n > 0, from('ok'), from('fail'));
+
+const label = cond<number, string>([
+  [(n) => n > 0, () => 'positive'],
+  [() => true, () => 'non-positive'] // default keeps it total
+]);
+```
+
+## `map` is for arrays/iterables (not single values)
+
+```ts
+const save = pipe(
+  (s: AppState) => JSON.stringify({ todos: s.todos, nextId: s.nextId }),
+  tap((json) => localStorage.setItem(STORAGE_KEY, json))
+);
+save(state);
+```
+
+## SideEffect pipelines and `runPipeResult` belong at the boundary
+
+```ts
+const pipeline = pipeSideEffect(findUser, (user) => user.email);
+const result = runPipeResult(pipeline(input)); // outside the pipeline
+```
+
+DOM APIs are imperative by nature. Keep them outside or at the boundary (use `tap` for final effects).

--- a/skills/fp-pack/constraints/core-rules.md
+++ b/skills/fp-pack/constraints/core-rules.md
@@ -1,0 +1,22 @@
+# Core Rules
+
+- Use `pipe`/`pipeAsync` for 2+ steps; for a single step, call the function directly.
+- Use `pipeStrict`/`pipeAsyncStrict` when you want stricter mismatch detection; otherwise stick to `pipe`/`pipeAsync`.
+- Prefer value-first: `pipe(value, ...)` / `pipeAsync(value, ...)` runs immediately and improves inference (the input anchors types). Use functions-first only when you need a reusable pipeline.
+- If the first arg is a function, it's treated as composition; wrap function values with `from()`.
+- Keep pipeline functions unary; prefer data-last, curried helpers.
+- `map`/`filter` are for arrays/iterables, not single values.
+- Use `from()` only for constants or 0-arg pipelines (including function values you need to pass as data). Otherwise pass data as the first argument.
+- Use `pipeSideEffect*` only when you need early exit; otherwise use `pipe`/`pipeAsync`.
+- Never call `runPipeResult`/`matchSideEffect` inside pipelines; call at boundaries.
+- Prefer `isSideEffect` for precise narrowing; `runPipeResult` for unwrapping (use generics if widened).
+- `SideEffect` is an instance type: use `SideEffect<E>` (not `typeof SideEffect`).
+- If TS inference stalls in data-last generics, use `pipeHint` or a tiny wrapper.
+- Use `fp-pack/stream` for large/lazy iterables; array/object utils for small/eager data.
+- Keep DOM/imperative work at the edge; use fp-pack for data transforms.
+- Avoid mutation; return new objects/arrays.
+- When unsure, check `dist/index.d.ts` or `dist/stream/index.d.ts`.
+
+Note: For trivial one-liners, using native JS directly is fine.
+Reach for fp-pack when composition adds clarity or reuse.
+Keep pipelines short and readable.

--- a/skills/fp-pack/constraints/troubleshooting.md
+++ b/skills/fp-pack/constraints/troubleshooting.md
@@ -1,0 +1,14 @@
+# Troubleshooting Type Errors (Fast Checks)
+
+- Is every step unary? (Pipelines expect one input each.)
+- Are you using array/iterable helpers (`map`, `filter`, `reduce`) on non-arrays?
+- Did you forget a default case in `cond` (`[() => true, () => ...]`)?
+- Are you returning `SideEffect` from a `pipe` pipeline? (Use `pipeSideEffect*`.)
+- Are you calling `runPipeResult` inside a pipeline? (Move it to the boundary.)
+- Are you mixing async steps in `pipe` instead of `pipeAsync`?
+- Did a data-last generic fail to infer? (Use `pipeHint` or a tiny wrapper.)
+- Are you using `from()` for constants only, not normal input?
+- Is a DOM/imperative step inside the pipeline? (Move it to the edge or use `tap`.)
+- Check `dist/index.d.ts` / `dist/stream/index.d.ts` for the expected signature.
+
+If the error persists, reduce the pipeline to the smallest failing step and add types there first.

--- a/skills/fp-pack/examples/quick-examples.md
+++ b/skills/fp-pack/examples/quick-examples.md
@@ -1,0 +1,44 @@
+# Quick Examples
+
+## Example 1: User Data Processing Pipeline
+
+```ts
+import { pipe, filter, map, take, sortBy } from 'fp-pack';
+
+const result = pipe(
+  users,
+  filter((user: User) => user.active),
+  sortBy((user) => -user.activityScore),
+  map((user) => user.name),
+  take(10)
+);
+```
+
+## Example 2: API Request with Early Exit
+
+```ts
+import { pipeAsyncSideEffect, SideEffect, runPipeResult } from 'fp-pack';
+
+const result = runPipeResult(
+  await pipeAsyncSideEffect(
+    'user-123',
+    async (userId: string) => {
+      const res = await fetch(`/api/users/${userId}`);
+      return res.ok ? res : SideEffect.of(() => `HTTP ${res.status}`);
+    },
+    async (res) => res.json()
+  )
+);
+```
+
+## Example 3: Value-first pipeline
+
+```ts
+import { pipe, filter, map } from 'fp-pack';
+
+const result = pipe(
+  [1, 2, 3, 4, 5],
+  filter((n: number) => n % 2 === 0),
+  map((n) => n * 2)
+);
+```

--- a/skills/fp-pack/reference/composition.md
+++ b/skills/fp-pack/reference/composition.md
@@ -1,0 +1,27 @@
+# Core Composition
+
+## `pipe` (sync)
+
+```ts
+import { pipe, filter, map, take } from 'fp-pack';
+
+const result = pipe(
+  users,
+  filter((u: User) => u.active),
+  map((u) => u.name),
+  take(10)
+);
+```
+
+## `pipeAsync` (async)
+
+```ts
+import { pipeAsync } from 'fp-pack';
+
+const user = await pipeAsync(
+  userId,
+  async (id: string) => fetch(`/api/users/${id}`),
+  async (res) => res.json(),
+  (data) => data.user
+);
+```

--- a/skills/fp-pack/reference/currying-data-last.md
+++ b/skills/fp-pack/reference/currying-data-last.md
@@ -1,0 +1,5 @@
+# Currying and Data-Last
+
+Most multi-arg helpers are data-last and curried. Pair them with value-first `pipe(value, ...)` to anchor types:
+- Good: `map(fn)`, `filter(pred)`, `replace(from, to)`, `assoc('k', v)`, `path(['a', 'b'])`
+- Single-arg helpers are already unary; use them directly

--- a/skills/fp-pack/reference/typescript-inference.md
+++ b/skills/fp-pack/reference/typescript-inference.md
@@ -1,0 +1,29 @@
+# TypeScript: Data-last Generic Inference
+
+Some data-last helpers return a generic function whose type is only determined by the final data argument. Prefer value-first `pipe(value, ...)` so the input anchors generics; use hints when needed.
+
+## Quick fix (pipeHint or wrapper)
+
+```ts
+import { pipe, pipeHint, zip, some } from 'fp-pack';
+
+// Prefer value-first to anchor generics
+const values: number[] = [1, 2, 3];
+const withValueFirst = pipe(
+  values,
+  zip([1, 2, 3]),
+  some(([a, b]) => a > b)
+);
+
+const withPipeHint = pipe(
+  pipeHint<number[], Array<[number, number]>>(zip([1, 2, 3])),
+  some(([a, b]) => a > b)
+);
+```
+
+If you prefer, a tiny wrapper like `(values) => zip([1, 2, 3], values)` works too.
+
+Utilities that may need a hint in data-last pipelines:
+- Array: `chunk`, `drop`, `take`, `zip`
+- Object: `assoc`, `assocPath`, `dissocPath`, `evolve`, `mapValues`, `merge`, `mergeDeep`, `omit`, `path`, `pick`, `prop`
+- Async: `timeout`


### PR DESCRIPTION
  This PR moves fp-pack’s AI skills from a single-file distribution to a folder-based skills package while keeping SKILL.md as the primary entry. It updates build output, docs, and guidance to reflect the new layout.

  What changed

  - Introduced skills/fp-pack/ with SKILL.md, examples/, reference/, and constraints/
  - Updated build script to copy the full skills package into dist/skills/
  - Removed legacy fp-pack.md
  - Updated README and docs to instruct copying the entire skills folder and linking SKILL.md when a single file is required
  - Updated add-on references to the new package path

  Notes

  - New skills package path: node_modules/fp-pack/dist/skills/fp-pack/
  - SKILL.md remains the primary entry point; additional materials are optional

  Tests

  - Not run (docs/build only)

  If you want a slightly more formal or shorter version, say the word and I’ll tweak it.